### PR TITLE
changed import instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
     </dependency>
     ```
 
-4. In every file that uses analytics, import com.amplitude.api at the top:
+4. In every file that uses analytics, import com.amplitude.api.Amplitude at the top:
 
     ```java
-    import package com.amplitude.api;
+    import com.amplitude.api.Amplitude;
     ```
 
 5. In the `onCreate()` of your main activity, initialize the SDK:


### PR DESCRIPTION
'import package' isn't proper syntax and gives an error, and it appears importing Amplitude directly with 'import com.amplitude.api.Amplitude' is a pretty consistent way to make it work
