### PR TITLE
Handle null edge cases in location request

### DIFF
--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -181,7 +181,16 @@ public class DeviceInfo {
 
         LocationManager locationManager = (LocationManager) context
                 .getSystemService(Context.LOCATION_SERVICE);
+
+        // Don't crash if the device does not have location services.
+        if (locationManager == null) { return null; }
+
         List<String> providers = locationManager.getProviders(true);
+
+        // It's possible that the location service is running out of process
+        // and the remote getProviders call fails. Handle null provider lists.
+        if (providers == null) { return null; }
+
         List<Location> locations = new ArrayList<Location>();
         for (String provider : providers) {
             Location location = locationManager.getLastKnownLocation(provider);

--- a/test/com/amplitude/api/DeviceInfoTest.java
+++ b/test/com/amplitude/api/DeviceInfoTest.java
@@ -1,6 +1,10 @@
 package com.amplitude.api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Locale;
 
@@ -14,6 +18,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowGeocoder;
+import org.robolectric.shadows.ShadowLocation;
 import org.robolectric.shadows.ShadowLocationManager;
 import org.robolectric.shadows.ShadowTelephonyManager;
 import org.robolectric.util.ReflectionHelpers;
@@ -156,6 +161,13 @@ public class DeviceInfoTest {
         locationManager.simulateLocation(loc);
         locationManager.setProviderEnabled(LocationManager.NETWORK_PROVIDER, true);
         assertEquals(loc, deviceInfo.getMostRecentLocation());
+    }
+
+    @Test
+    public void testNoLocation() {
+        DeviceInfo deviceInfo = new DeviceInfo(context);
+        Location recent = deviceInfo.getMostRecentLocation();
+        assertNull(recent);
     }
 
 }


### PR DESCRIPTION
Location handling has a couple of extreme edge cases that produce null values. Handle those cases to avoid crashing.

Fix for #16.