### PR TITLE
Get User Properties and Report Event Logging to Listeners

### DIFF
--- a/android-sdk.iml
+++ b/android-sdk.iml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: com.squareup.okhttp:okhttp:2.2.0" level="project" />
+    <orderEntry type="library" name="Maven: com.squareup.okio:okio:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.robolectric:robolectric:3.0-rc2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.8.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.robolectric:robolectric-annotations:3.0-rc2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.robolectric:robolectric-resources:3.0-rc2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.robolectric:robolectric-utils:3.0-rc2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.robolectric:shadows-core:21:3.0-rc2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.ibm.icu:icu4j:53.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.almworks.sqlite4java:sqlite4java:0.282" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.bouncycastle:bcprov-jdk16:1.46" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:5.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm-commons:5.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm-tree:5.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm-util:5.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm-analysis:5.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-logging:commons-logging:1.1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.ximpleware:vtd-xml:2.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven:maven-ant-tasks:2.1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant:1.8.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant-launcher:1.8.0" level="project" />
+  </component>
+</module>

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -193,7 +193,7 @@ public class AmplitudeClient {
     }
 
     private void checkedLogEvent(final String eventType, final JSONObject eventProperties,
-            final JSONObject apiProperties, final long timestamp, final boolean checkSession) {
+                                 final JSONObject apiProperties, final long timestamp, final boolean checkSession) {
         if (TextUtils.isEmpty(eventType)) {
             Log.e(TAG, "Argument eventType cannot be null or blank in logEvent()");
             return;
@@ -210,7 +210,7 @@ public class AmplitudeClient {
     }
 
     private long logEvent(String eventType, JSONObject eventProperties,
-            JSONObject apiProperties, long timestamp, boolean checkSession) {
+                          JSONObject apiProperties, long timestamp, boolean checkSession) {
         Log.d(TAG, "Logged event to Amplitude: " + eventType);
 
         if (optOut) {
@@ -267,6 +267,8 @@ public class AmplitudeClient {
             Log.e(TAG, e.toString());
         }
 
+        reportEvent(eventType);
+
         return saveEvent(event);
     }
 
@@ -284,6 +286,14 @@ public class AmplitudeClient {
             updateServerLater(Constants.EVENT_UPLOAD_PERIOD_MILLIS);
         }
         return eventId;
+    }
+
+    /**
+     * Register a callback reporting event
+     * to act as hook for other platforms
+     */
+    public void reportEvent(JSONObject event){
+        // do something with event
     }
 
     /**
@@ -514,7 +524,7 @@ public class AmplitudeClient {
     }
 
     public void logRevenue(String productId, int quantity, double price, String receipt,
-            String receiptSignature) {
+                           String receiptSignature) {
         if (!contextAndApiKeySet("logRevenue()")) {
             return;
         }
@@ -565,6 +575,17 @@ public class AmplitudeClient {
                 }
             }
         });
+    }
+
+    /**
+     * Allow to get the user properties
+     */
+
+    public JSONObject getUserProperties() {
+        if(userProperties != null){
+            return userProperties;
+        }
+        return null;
     }
 
     public void setUserId(String userId) {
@@ -630,17 +651,17 @@ public class AmplitudeClient {
         }
 
         RequestBody body = new FormEncodingBuilder()
-            .add("v", apiVersionString)
-            .add("client", apiKey)
-            .add("e", events)
-            .add("upload_time", timestampString)
-            .add("checksum", checksumString)
-            .build();
+                .add("v", apiVersionString)
+                .add("client", apiKey)
+                .add("e", events)
+                .add("upload_time", timestampString)
+                .add("checksum", checksumString)
+                .build();
 
         Request request = new Request.Builder()
-            .url(url)
-            .post(body)
-            .build();
+                .url(url)
+                .post(body)
+                .build();
 
         boolean uploadSuccess = false;
 

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -270,7 +270,7 @@ public class AmplitudeClient {
             Log.e(TAG, e.toString());
         }
 
-        reportEvent(JSONObject event);
+        reportEvent(event);
 
         return saveEvent(event);
     }

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.EventListener;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -267,7 +268,7 @@ public class AmplitudeClient {
             Log.e(TAG, e.toString());
         }
 
-        reportEvent(eventType);
+        EventListener.addToEventListener(JSONObject event);
 
         return saveEvent(event);
     }
@@ -288,13 +289,6 @@ public class AmplitudeClient {
         return eventId;
     }
 
-    /**
-     * Register a callback reporting event
-     * to act as hook for other platforms
-     */
-    public void reportEvent(JSONObject event){
-        // do something with event
-    }
 
     /**
      * Do a shallow copy of a JSONObject. Takes a bit of code to avoid

--- a/src/com/amplitude/api/EventListener.java
+++ b/src/com/amplitude/api/EventListener.java
@@ -1,0 +1,7 @@
+package com.amplitude.api;
+
+import org.json.JSONObject;
+
+public interface EventListeningInterface {
+    void addToEventListener(JSONObject jsonObject);
+}

--- a/src/com/amplitude/api/EventListener.java
+++ b/src/com/amplitude/api/EventListener.java
@@ -3,5 +3,5 @@ package com.amplitude.api;
 import org.json.JSONObject;
 
 public interface EventListeningInterface {
-    void addToEventListener(JSONObject jsonObject);
+    void trackEvent(JSONObject jsonObject);
 }


### PR DESCRIPTION
Hey Curtis + Amplitude dev team, let me know what you think about the following changes!

Adding the functionality to get the user properties stored in Amplitude client would allow for other platforms to be able to use Amplitude's segments. Very helpful for integrations.

Similarly, allowing for other platforms to listen to the events that are being logged by Amplitude. I've included the entire event, but even limiting it to the event type string would be awesome. 

Apologies for the formatting changes in the commit. Changes in AmplitudeClient are around the following lines:
- Line 78
- Line 273
- Line 580 - 585
- Line 900+
