### PR TITLE
Disable Log.DEBUG statements by default.

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -51,6 +51,7 @@ public class AmplitudeClient {
     private boolean initialized = false;
     private boolean optOut = false;
     private boolean offline = false;
+    private boolean debugLogEnabled = false;
 
     private DeviceInfo deviceInfo;
     private String advertisingId;
@@ -185,6 +186,10 @@ public class AmplitudeClient {
         }
     }
 
+    public void setDebugLogEnabled(boolean debugLogEnabled) {
+        this.debugLogEnabled = debugLogEnabled;
+    }
+
     public void logEvent(String eventType) {
         logEvent(eventType, null);
     }
@@ -236,7 +241,9 @@ public class AmplitudeClient {
 
     protected long logEvent(String eventType, JSONObject eventProperties,
             JSONObject apiProperties, long timestamp, boolean checkSession) {
-        Log.d(TAG, "Logged event to Amplitude: " + eventType);
+        if (debugLogEnabled) {
+            Log.d(TAG, "Logged event to Amplitude: " + eventType);
+        }
 
         if (optOut) {
             return -1;


### PR DESCRIPTION
As ours is a privacy-enhancing app, we'd prefer not to have our event names shown in logcat.

This diff disables debug-level android.Log statements by default, and adds a method to enable them.  Currently there's only one such statement; the rest of the log statements in AmplitudeClient primarily communicate developer errors, and are left on by default here.