### PR TITLE
Re-use OkHttpClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *~
 dist/
 *.asc
+# Intellij
+.idea/
+*.iml
+

--- a/src/com/amplitude/api/Amplitude.java
+++ b/src/com/amplitude/api/Amplitude.java
@@ -19,7 +19,7 @@ public class Amplitude {
 
     @Deprecated
     public static void initialize(Context context, String apiKey, String userId) {
-        getInstance().initialize(context, apiKey, userId);
+        getInstance().initialize(context, apiKey, userId, null);
     }
 
     @Deprecated

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -43,6 +43,7 @@ public class AmplitudeClient {
     }
 
     protected Context context;
+    protected OkHttpClient httpClient;
     protected String apiKey;
     protected String userId;
     protected String deviceId;
@@ -93,10 +94,14 @@ public class AmplitudeClient {
     }
 
     public void initialize(Context context, String apiKey) {
-        initialize(context, apiKey, null);
+        initialize(context, apiKey, null, null);
     }
 
-    public synchronized void initialize(Context context, String apiKey, String userId) {
+    public void initialize(Context context, String apiKey, OkHttpClient okHttpClient) {
+        initialize(context, apiKey, null, okHttpClient);
+    }
+
+    public synchronized void initialize(Context context, String apiKey, String userId, OkHttpClient okHttpClient) {
         if (context == null) {
             Log.e(TAG, "Argument context cannot be null in initialize()");
             return;
@@ -110,6 +115,7 @@ public class AmplitudeClient {
         }
         if (!initialized) {
             this.context = context.getApplicationContext();
+            this.httpClient = okHttpClient == null ? new OkHttpClient(): okHttpClient;
             this.apiKey = apiKey;
             initializeDeviceInfo();
             SharedPreferences preferences = context.getSharedPreferences(
@@ -619,7 +625,7 @@ public class AmplitudeClient {
                 httpThread.post(new Runnable() {
                     @Override
                     public void run() {
-                        makeEventUploadPostRequest(new OkHttpClient(), events.toString(), maxId);
+                        makeEventUploadPostRequest(httpClient, events.toString(), maxId);
                     }
                 });
             } catch (JSONException e) {

--- a/src/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -14,7 +14,7 @@ public class AmplitudePlugin {
     }
 
     public static void init(Context context, String apiKey, String userId) {
-        Amplitude.getInstance().initialize(context, apiKey, userId);
+        Amplitude.getInstance().initialize(context, apiKey, userId, null);
     }
 
     public static void startSession() {


### PR DESCRIPTION
* Also enable using a custom OkHttpClient

Jake Wharton mentioned:
```
One OkHttpClient per request is bad. You just lose the shared thread pool and route information.
```