### PR TITLE
Add target/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.asc
 .idea/
 *.iml
+target/


### PR DESCRIPTION
The Maven build output directory should not show up in `git status`
