### PR TITLE
Don't fetch device ID on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
+* Fix bug where deviceId was being fetched on main thread.
+
 ## 2.0.2 (August 24, 2015)
 
-* Fixed Maven jar, fixed build file
+* Fix Maven jar, fixed build file
 
 ## 2.0.1 (August 21, 2015)
 

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -502,9 +502,14 @@ public class AmplitudeClient {
         logEvent(sessionEvent, null, apiProperties, timestamp, false);
     }
 
-    void onExitForeground(long timestamp) {
-        refreshSessionTime(timestamp);
-        inForeground = false;
+    void onExitForeground(final long timestamp) {
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                refreshSessionTime(timestamp);
+                inForeground = false;
+            }
+        });
     }
 
     void onEnterForeground(final long timestamp) {

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1,24 +1,5 @@
 package com.amplitude.api;
 
-import com.amplitude.security.MD5;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
-import com.squareup.okhttp.FormEncodingBuilder;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -27,6 +8,25 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
+
+import com.amplitude.security.MD5;
+import com.squareup.okhttp.FormEncodingBuilder;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AmplitudeClient {
 
@@ -507,9 +507,14 @@ public class AmplitudeClient {
         inForeground = false;
     }
 
-    void onEnterForeground(long timestamp) {
-        startNewSessionIfNeeded(timestamp);
-        inForeground = true;
+    void onEnterForeground(final long timestamp) {
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                startNewSessionIfNeeded(timestamp);
+                inForeground = true;
+            }
+        });
     }
 
     public void logRevenue(double amount) {

--- a/test/com/amplitude/api/SessionTest.java
+++ b/test/com/amplitude/api/SessionTest.java
@@ -1,11 +1,7 @@
 package com.amplitude.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +10,10 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -420,6 +420,7 @@ public class SessionTest extends BaseTest {
         assertFalse(amplitude.isInForeground());
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertTrue(amplitude.isInForeground());
         assertEquals(amplitude.getPreviousSessionId(), timestamp);
         assertEquals(amplitude.getLastEventId(), -1);
@@ -476,6 +477,7 @@ public class SessionTest extends BaseTest {
         assertEquals(amplitude.getLastEventTime(), -1);
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
@@ -536,6 +538,7 @@ public class SessionTest extends BaseTest {
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
@@ -552,6 +555,7 @@ public class SessionTest extends BaseTest {
 
         // resume after min session expired window, verify new session started
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[2]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[2]);
@@ -651,6 +655,7 @@ public class SessionTest extends BaseTest {
         assertEquals(amplitude.getLastEventTime(), -1);
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
@@ -662,6 +667,7 @@ public class SessionTest extends BaseTest {
         assertFalse(amplitude.isInForeground());
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[2]);
@@ -744,6 +750,7 @@ public class SessionTest extends BaseTest {
         assertEquals(getUnsentEventCount(), 1);
 
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamp);
         assertEquals(amplitude.getLastEventId(), 1);
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
@@ -782,6 +789,7 @@ public class SessionTest extends BaseTest {
 
         // onResume after session expires will start new session
         callBacks.onActivityResumed(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), 4);
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);

--- a/test/com/amplitude/api/SessionTest.java
+++ b/test/com/amplitude/api/SessionTest.java
@@ -483,6 +483,7 @@ public class SessionTest extends BaseTest {
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
 
         callBacks.onActivityPaused(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[1]);
@@ -547,6 +548,7 @@ public class SessionTest extends BaseTest {
 
         // only refresh time, no session checking
         callBacks.onActivityPaused(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[1]);
@@ -661,6 +663,7 @@ public class SessionTest extends BaseTest {
         assertEquals(amplitude.getLastEventTime(), timestamps[0]);
 
         callBacks.onActivityPaused(null);
+        Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
         assertEquals(amplitude.getLastEventId(), -1);
         assertEquals(amplitude.getLastEventTime(), timestamps[1]);


### PR DESCRIPTION
This is caused by onEnterForeground which can send start/end session events on main thread. The fix is to start new session if necessary on the background thread. Start new session should still log events synchronously (in the case where logging an event starts a new session, we want the start/end session events to be sent before the logged event).

It should be okay to toggle the inForeground boolean on the background thread, since log event is the only function that uses it, and that should be called on the background thread.