### PR TITLE
Log if Google Play Services enabled in api properties['gps_enabled']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Log if Google Play Services is enabled for the application.
+
 ## 2.2.0 (October 20, 2015)
 
 * Removed all references to Apache HTTPClient to support Android M.

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
       <scope>system</scope>
       <systemPath>${basedir}/lib/google-play-services-25.0.0.jar</systemPath>
     </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>support-v4</artifactId>
+      <version>r6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <developers>

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -373,6 +373,7 @@ public class AmplitudeClient {
                 apiProperties.put("androidADID", deviceInfo.getAdvertisingId());
             }
             apiProperties.put("limit_ad_tracking", deviceInfo.isLimitAdTrackingEnabled());
+            apiProperties.put("gps_enabled", deviceInfo.isGPSEnabled());
 
             event.put("api_properties", apiProperties);
             event.put("event_properties", (eventProperties == null) ? new JSONObject()

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -373,7 +373,7 @@ public class AmplitudeClient {
                 apiProperties.put("androidADID", deviceInfo.getAdvertisingId());
             }
             apiProperties.put("limit_ad_tracking", deviceInfo.isLimitAdTrackingEnabled());
-            apiProperties.put("gps_enabled", deviceInfo.isGPSEnabled());
+            apiProperties.put("gps_enabled", deviceInfo.isGooglePlayServicesEnabled());
 
             event.put("api_properties", apiProperties);
             event.put("event_properties", (eventProperties == null) ? new JSONObject()

--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -291,7 +291,7 @@ public class DeviceInfo {
         return getCachedInfo().limitAdTrackingEnabled;
     }
 
-    public boolean isGPSEnabled() { return getCachedInfo().gpsEnabled; }
+    public boolean isGooglePlayServicesEnabled() { return getCachedInfo().gpsEnabled; }
 
     public Location getMostRecentLocation() {
         if (!isLocationListening()) {

--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -46,6 +46,7 @@ public class DeviceInfo {
         private String carrier;
         private String language;
         private boolean limitAdTrackingEnabled;
+        private boolean gpsEnabled; // google play services
 
         private CachedInfo() {
             advertisingId = getAdvertisingId();
@@ -58,6 +59,7 @@ public class DeviceInfo {
             carrier = getCarrier();
             country = getCountry();
             language = getLanguage();
+            gpsEnabled = checkGPSEnabled();
         }
 
         /**
@@ -197,6 +199,33 @@ public class DeviceInfo {
             }
             return advertisingId;
         }
+
+        private boolean checkGPSEnabled() {
+            // This should not be called on the main thread.
+            try {
+                Class GPSUtil = Class
+                        .forName("com.google.android.gms.common.GooglePlayServicesUtil");
+                Method getGPSAvailable = GPSUtil.getMethod("isGooglePlayServicesAvailable",
+                        Context.class);
+                Integer status = (Integer) getGPSAvailable.invoke(null, context);
+                // status 0 corresponds to com.google.android.gms.common.ConnectionResult.SUCCESS;
+                return status != null && status.intValue() == 0;
+            } catch (NoClassDefFoundError e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services Util not found!");
+            } catch (ClassNotFoundException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services Util not found!");
+            } catch (NoSuchMethodException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+            } catch (InvocationTargetException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+            } catch (IllegalAccessException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+            } catch (Exception e) {
+                AmplitudeLog.getLogger().w(TAG,
+                        "Error when checking for Google Play Services: " + e);
+            }
+            return false;
+        }
     }
 
     public DeviceInfo(Context context) {
@@ -261,6 +290,8 @@ public class DeviceInfo {
     public boolean isLimitAdTrackingEnabled() {
         return getCachedInfo().limitAdTrackingEnabled;
     }
+
+    public boolean isGPSEnabled() { return getCachedInfo().gpsEnabled; }
 
     public Location getMostRecentLocation() {
         if (!isLocationListening()) {

--- a/test/com/amplitude/api/DeviceInfoTest.java
+++ b/test/com/amplitude/api/DeviceInfoTest.java
@@ -190,7 +190,7 @@ public class DeviceInfoTest {
     public void testGPSDisabled() {
         // GPS not enabled
         DeviceInfo deviceInfo = new DeviceInfo(context);
-        assertFalse(deviceInfo.isGPSEnabled());
+        assertFalse(deviceInfo.isGooglePlayServicesEnabled());
 
         // GPS bundled but not enabled, GooglePlayUtils.isAvailable returns non-0 value
         PowerMockito.mockStatic(GooglePlayServicesUtil.class);
@@ -200,7 +200,7 @@ public class DeviceInfoTest {
         } catch (Exception e) {
             fail(e.toString());
         }
-        assertFalse(deviceInfo.isGPSEnabled());
+        assertFalse(deviceInfo.isGooglePlayServicesEnabled());
     }
 
     @Test
@@ -212,7 +212,7 @@ public class DeviceInfoTest {
         } catch (Exception e) {
             fail(e.toString());
         }
-        assert(deviceInfo.isGPSEnabled());
+        assert(deviceInfo.isGooglePlayServicesEnabled());
     }
 
     @Test

--- a/test/com/amplitude/api/DeviceInfoTest.java
+++ b/test/com/amplitude/api/DeviceInfoTest.java
@@ -166,7 +166,7 @@ public class DeviceInfoTest {
     }
 
     @Test
-     public void testGetAdvertisingId() {
+    public void testGetAdvertisingId() {
         PowerMockito.mockStatic(AdvertisingIdClient.class);
         String advertisingId = "advertisingId";
         AdvertisingIdClient.Info info = new AdvertisingIdClient.Info(

--- a/test/com/amplitude/api/DeviceInfoTest.java
+++ b/test/com/amplitude/api/DeviceInfoTest.java
@@ -9,6 +9,8 @@ import android.os.Build;
 import android.telephony.TelephonyManager;
 
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +42,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*" })
-@PrepareForTest(AdvertisingIdClient.class)
+@PrepareForTest({AdvertisingIdClient.class, GooglePlayServicesUtil.class})
 @Config(manifest = Config.NONE)
 public class DeviceInfoTest {
 
@@ -164,7 +166,7 @@ public class DeviceInfoTest {
     }
 
     @Test
-    public void testGetAdvertisingId() {
+     public void testGetAdvertisingId() {
         PowerMockito.mockStatic(AdvertisingIdClient.class);
         String advertisingId = "advertisingId";
         AdvertisingIdClient.Info info = new AdvertisingIdClient.Info(
@@ -185,6 +187,35 @@ public class DeviceInfoTest {
     }
 
     @Test
+    public void testGPSDisabled() {
+        // GPS not enabled
+        DeviceInfo deviceInfo = new DeviceInfo(context);
+        assertFalse(deviceInfo.isGPSEnabled());
+
+        // GPS bundled but not enabled, GooglePlayUtils.isAvailable returns non-0 value
+        PowerMockito.mockStatic(GooglePlayServicesUtil.class);
+        try {
+            Mockito.when(GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                    .thenReturn(1);
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+        assertFalse(deviceInfo.isGPSEnabled());
+    }
+
+    @Test
+    public void testGPSEnabled() {
+        PowerMockito.mockStatic(GooglePlayServicesUtil.class);
+        try {
+            Mockito.when(GooglePlayServicesUtil.isGooglePlayServicesAvailable(context))
+                    .thenReturn(ConnectionResult.SUCCESS);
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+        assert(deviceInfo.isGPSEnabled());
+    }
+
+    @Test
     public void testGetMostRecentLocation() {
         DeviceInfo deviceInfo = new DeviceInfo(context);
         ShadowLocationManager locationManager = Shadows.shadowOf((LocationManager) context
@@ -202,5 +233,4 @@ public class DeviceInfoTest {
         Location recent = deviceInfo.getMostRecentLocation();
         assertNull(recent);
     }
-
 }


### PR DESCRIPTION
The standard way to check if GPS enabled is this:
```
int statusCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(context);
if (statusCode == ConnectionResult.SUCCESS) {
    ...
}
```

Note: You will notice that on Line 212 I do statusCode == 0, instead of ConnectionResult.SUCCESS, because ConnectionResult is another gms library and I don't want to load that through reflection just to get the value of [success, which is just 0 anyways](https://developers.google.com/android/reference/com/google/android/gms/common/ConnectionResult.html#SUCCESS).

I do have a test (testGPSEnabled), which does use ConnectionResult.SUCCESS, which will break and let us know if Google ever decides to change the mapped value. I also tested it on the Android demo (with GPS enabled and disabled).
