### PR TITLE
Append operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add support for append user property operation.
+
 ## 2.3.0 (November 30, 2015)
 
 * Log if Google Play Services is enabled for the application.

--- a/README.md
+++ b/README.md
@@ -178,10 +178,9 @@ import com.amplitude.api.Identify;
 5. `append`: this will append a value or values to a user property. If the user property does not have a value set yet, it will be initialized to an empty list before the new values are appended. If the user property has an existing value and it is not a list, it will be converted into a list with the new value appended.
 
     ```java
-    Identify identify = new Identify().append("ab-tests", "new-user-test").append("some_list", new int[]{1, 2, 3});
+    Identify identify = new Identify().append("ab-tests", "new-user-test").append("some_list", new JSONArray().put(1).put("some_string"));
     Amplitude.getInstance().identify(identify);
     ```
-
 
 Note: if a user property is used in multiple operations on the same `Identify` object, only the first operation will be saved, and the rest will be ignored. In this example, only the set operation will be saved, and the add and unset will be ignored:
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ import com.amplitude.api.Identify;
     Amplitude.getInstance().identify(identify);
     ```
 
+5. `append`: this will append a value or values to a user property. If the user property does not have a value set yet, it will be initialized to an empty list before the new values are appended. If the user property has an existing value and it is not a list, it will be converted into a list with the new value appended.
+
+    ```java
+    Identify identify = new Identify().append("ab-tests", "new-user-test").append("some_list", new int[]{1, 2, 3});
+    Amplitude.getInstance().identify(identify);
+    ```
+
+
 Note: if a user property is used in multiple operations on the same `Identify` object, only the first operation will be saved, and the rest will be ignored. In this example, only the set operation will be saved, and the add and unset will be ignored:
 
 ```java

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -648,7 +648,7 @@ public class AmplitudeClient {
                 while (keys.hasNext()) {
                     String key = (String) keys.next();
                     try {
-                        identify.set(key, copy.get(key));
+                        identify.setUserProperty(key, copy.get(key));
                     } catch (JSONException e) {
                         logger.e(TAG, e.toString());
                     }

--- a/src/com/amplitude/api/Constants.java
+++ b/src/com/amplitude/api/Constants.java
@@ -37,5 +37,6 @@ public class Constants {
     public static final String AMP_OP_SET = "$set";
     public static final String AMP_OP_SET_ONCE = "$setOnce";
     public static final String AMP_OP_ADD = "$add";
+    public static final String AMP_OP_APPEND = "$append";
     public static final String AMP_OP_UNSET = "$unset";
 }

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -3,7 +3,9 @@ package com.amplitude.api;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /*
@@ -70,6 +72,44 @@ public class Identify {
         addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
+
+    public Identify append(String property, float [] values) {
+        List<Float> valuesArray = new ArrayList<Float>(values.length);
+        for (float value : values) {
+            valuesArray.add(value);
+        }
+        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+        return this;
+    }
+
+    public Identify append(String property, int [] values) {
+        List<Integer> valuesArray = new ArrayList<Integer>(values.length);
+        for (int value : values) {
+            valuesArray.add(value);
+        }
+        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+        return this;
+    }
+
+    public Identify append(String property, long [] values) {
+        List<Long> valuesArray = new ArrayList<Long>(values.length);
+        for (long value : values) {
+            valuesArray.add(value);
+        }
+        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+        return this;
+    }
+
+    public Identify append(String property, double [] values) {
+        List<Double> valuesArray = new ArrayList<Double>(values.length);
+        for (double value : values) {
+            valuesArray.add(value);
+        }
+        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+        return this;
+    }
+
+
 
     public Identify unset(String property) {
         addToUserProperties(Constants.AMP_OP_UNSET, property, "-");

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -46,6 +46,31 @@ public class Identify {
         return this;
     }
 
+    public Identify append(String property, Object value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
+    public Identify append(String property, float value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
+    public Identify append(String property, int value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
+    public Identify append(String property, long value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
+    public Identify append(String property, double value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
     public Identify unset(String property) {
         addToUserProperties(Constants.AMP_OP_UNSET, property, "-");
         return this;

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -182,6 +182,7 @@ public class Identify {
         return this;
     }
 
+    // Server-side converts string numbers to numbers
     public Identify add(String property, String value) {
         addToUserProperties(Constants.AMP_OP_ADD, property, value);
         return this;
@@ -315,7 +316,7 @@ public class Identify {
                 array.put(value);
             } catch (JSONException e) {
                 AmplitudeLog.getLogger().e(TAG, String.format(
-                        "Error converting float %f to JSON: %s", value, e.toString()
+                    "Error converting float %f to JSON: %s", value, e.toString()
                 ));
             }
         }
@@ -329,7 +330,7 @@ public class Identify {
                 array.put(value);
             } catch (JSONException e) {
                 AmplitudeLog.getLogger().e(TAG, String.format(
-                        "Error converting double %d to JSON: %s", value, e.toString()
+                    "Error converting double %d to JSON: %s", value, e.toString()
                 ));
             }
         }
@@ -360,7 +361,7 @@ public class Identify {
         return this;
     }
 
-    // DEPRECATED - Object class is too general
+    // DEPRECATED - Signature is too general
     public Identify setOnce(String property, Object value) {
         AmplitudeLog.getLogger().w(
             TAG,
@@ -369,7 +370,7 @@ public class Identify {
         return this;
     }
 
-    // DEPRECATED - Object class is too general
+    // DEPRECATED - Signature is too general
     public Identify set(String property, Object value) {
         AmplitudeLog.getLogger().w(
             TAG,

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -99,7 +99,6 @@ public class Identify {
         return this;
     }
 
-
     // ADD
     public Identify add(String property, String value) {
         addToUserProperties(Constants.AMP_OP_ADD, property, value);

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -1,11 +1,10 @@
 package com.amplitude.api;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /*
@@ -18,13 +17,91 @@ public class Identify {
     protected JSONObject userPropertiesOperations = new JSONObject();
     protected Set<String> userProperties = new HashSet<String>();
 
-    public Identify setOnce(String property, Object value) {
+    // SET
+    public Identify set(String property, String value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, boolean value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, float value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, int value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, long value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, double value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, JSONObject value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    public Identify set(String property, JSONArray value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
+    }
+
+    // SETONCE
+    public Identify setOnce(String property, String value) {
         addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
         return this;
     }
 
-    public Identify set(String property, Object value) {
-        addToUserProperties(Constants.AMP_OP_SET, property, value);
+    public Identify setOnce(String property, boolean value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, float value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, int value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, long value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, double value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, JSONArray value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, JSONObject value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    // ADD
+    public Identify add(String property, String value) {
+        addToUserProperties(Constants.AMP_OP_ADD, property, value);
         return this;
     }
 
@@ -48,7 +125,13 @@ public class Identify {
         return this;
     }
 
-    public Identify append(String property, Object value) {
+    // APPEND
+    public Identify append(String property, String value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+        return this;
+    }
+
+    public Identify append(String property, boolean value) {
         addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
@@ -73,44 +156,17 @@ public class Identify {
         return this;
     }
 
-    public Identify append(String property, float [] values) {
-        List<Float> valuesArray = new ArrayList<Float>(values.length);
-        for (float value : values) {
-            valuesArray.add(value);
-        }
-        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+    public Identify append(String property, JSONArray value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
 
-    public Identify append(String property, int [] values) {
-        List<Integer> valuesArray = new ArrayList<Integer>(values.length);
-        for (int value : values) {
-            valuesArray.add(value);
-        }
-        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
+    public Identify append(String property, JSONObject value) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
 
-    public Identify append(String property, long [] values) {
-        List<Long> valuesArray = new ArrayList<Long>(values.length);
-        for (long value : values) {
-            valuesArray.add(value);
-        }
-        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
-        return this;
-    }
-
-    public Identify append(String property, double [] values) {
-        List<Double> valuesArray = new ArrayList<Double>(values.length);
-        for (double value : values) {
-            valuesArray.add(value);
-        }
-        addToUserProperties(Constants.AMP_OP_ADD, property, valuesArray);
-        return this;
-    }
-
-
-
+    // UNSET
     public Identify unset(String property) {
         addToUserProperties(Constants.AMP_OP_UNSET, property, "-");
         return this;
@@ -132,5 +188,17 @@ public class Identify {
         } catch (JSONException e) {
             AmplitudeLog.getLogger().e(TAG, e.toString());
         }
+    }
+
+    // DEPRECATED - Object class is too general
+    public Identify setOnce(String property, Object value) {
+        AmplitudeLog.getLogger().w(TAG, String.format("This version of setOnce is deprecated. Please use one with a different signature."));
+        return this;
+    }
+
+    // DEPRECATED - Object class is too general
+    public Identify set(String property, Object value) {
+        AmplitudeLog.getLogger().w(TAG, String.format("This version of set is deprecated. Please use one with a different signature."));
+        return this;
     }
 }

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -17,6 +17,47 @@ public class Identify {
     protected JSONObject userPropertiesOperations = new JSONObject();
     protected Set<String> userProperties = new HashSet<String>();
 
+    // SETONCE
+    public Identify setOnce(String property, String value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, boolean value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, float value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, int value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, long value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, double value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, JSONArray value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
+    public Identify setOnce(String property, JSONObject value) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+        return this;
+    }
+
     // SET
     public Identify set(String property, String value) {
         addToUserProperties(Constants.AMP_OP_SET, property, value);
@@ -58,46 +99,6 @@ public class Identify {
         return this;
     }
 
-    // SETONCE
-    public Identify setOnce(String property, String value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, boolean value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, float value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, int value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, long value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, double value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, JSONArray value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
-
-    public Identify setOnce(String property, JSONObject value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
-        return this;
-    }
 
     // ADD
     public Identify add(String property, String value) {
@@ -188,6 +189,12 @@ public class Identify {
         } catch (JSONException e) {
             AmplitudeLog.getLogger().e(TAG, e.toString());
         }
+    }
+
+    // Package private method - used by AmplitudeClient to convert setUserProperties to identify
+    Identify setUserProperty(String property, Object value) {
+        addToUserProperties(Constants.AMP_OP_SET, property, value);
+        return this;
     }
 
     // DEPRECATED - Object class is too general

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -18,12 +18,12 @@ public class Identify {
     protected Set<String> userProperties = new HashSet<String>();
 
     // SETONCE
-    public Identify setOnce(String property, String value) {
+    public Identify setOnce(String property, boolean value) {
         addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
         return this;
     }
 
-    public Identify setOnce(String property, boolean value) {
+    public Identify setOnce(String property, double value) {
         addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
         return this;
     }
@@ -43,7 +43,7 @@ public class Identify {
         return this;
     }
 
-    public Identify setOnce(String property, double value) {
+    public Identify setOnce(String property, String value) {
         addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
         return this;
     }
@@ -58,13 +58,44 @@ public class Identify {
         return this;
     }
 
+    public Identify setOnce(String property, boolean[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, booleanArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify setOnce(String property, double[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, doubleArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify setOnce(String property, float[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, floatArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify setOnce(String property, int[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, intArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify setOnce(String property, long[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, longArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify setOnce(String property, String[] values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, stringArrayToJSONArray(values));
+        return this;
+    }
+
+
     // SET
-    public Identify set(String property, String value) {
+    public Identify set(String property, boolean value) {
         addToUserProperties(Constants.AMP_OP_SET, property, value);
         return this;
     }
 
-    public Identify set(String property, boolean value) {
+    public Identify set(String property, double value) {
         addToUserProperties(Constants.AMP_OP_SET, property, value);
         return this;
     }
@@ -84,7 +115,7 @@ public class Identify {
         return this;
     }
 
-    public Identify set(String property, double value) {
+    public Identify set(String property, String value) {
         addToUserProperties(Constants.AMP_OP_SET, property, value);
         return this;
     }
@@ -99,8 +130,39 @@ public class Identify {
         return this;
     }
 
+    public Identify set(String property, boolean[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, booleanArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify set(String property, double[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, doubleArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify set(String property, float[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, floatArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify set(String property, int[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, intArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify set(String property, long[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, longArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify set(String property, String[] values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, stringArrayToJSONArray(values));
+        return this;
+    }
+
+
     // ADD
-    public Identify add(String property, String value) {
+    public Identify add(String property, double value) {
         addToUserProperties(Constants.AMP_OP_ADD, property, value);
         return this;
     }
@@ -120,18 +182,19 @@ public class Identify {
         return this;
     }
 
-    public Identify add(String property, double value) {
+    public Identify add(String property, String value) {
         addToUserProperties(Constants.AMP_OP_ADD, property, value);
         return this;
     }
 
+
     // APPEND
-    public Identify append(String property, String value) {
+    public Identify append(String property, boolean value) {
         addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
 
-    public Identify append(String property, boolean value) {
+    public Identify append(String property, double value) {
         addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
@@ -151,7 +214,7 @@ public class Identify {
         return this;
     }
 
-    public Identify append(String property, double value) {
+    public Identify append(String property, String value) {
         addToUserProperties(Constants.AMP_OP_APPEND, property, value);
         return this;
     }
@@ -161,10 +224,36 @@ public class Identify {
         return this;
     }
 
-    public Identify append(String property, JSONObject value) {
-        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+    public Identify append(String property, boolean[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, booleanArrayToJSONArray(values));
         return this;
     }
+
+    public Identify append(String property, double[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, doubleArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify append(String property, float[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, floatArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify append(String property, int[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, intArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify append(String property, long[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, longArrayToJSONArray(values));
+        return this;
+    }
+
+    public Identify append(String property, String[] values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, stringArrayToJSONArray(values));
+        return this;
+    }
+
 
     // UNSET
     public Identify unset(String property) {
@@ -173,9 +262,20 @@ public class Identify {
     }
 
     private void addToUserProperties(String operation, String property, Object value) {
+        if (value == null) {
+            AmplitudeLog.getLogger().w(TAG, String.format(
+                "Attempting to perform operation %s with null value for property %s, ignoring",
+                operation, property
+            ));
+            return;
+        }
+
         // check if property already used in previous operation
         if (userProperties.contains(property)) {
-            AmplitudeLog.getLogger().w(TAG, String.format("Already used property %s in previous operation, ignoring operation %s", property, operation));
+            AmplitudeLog.getLogger().w(TAG, String.format(
+                "Already used property %s in previous operation, ignoring operation %s",
+                property, operation
+            ));
             return;
         }
 
@@ -190,6 +290,58 @@ public class Identify {
         }
     }
 
+    private JSONArray stringArrayToJSONArray(String[] values) {
+        JSONArray array = new JSONArray();
+        for (String value : values) array.put(value);
+        return array;
+    }
+
+    private JSONArray booleanArrayToJSONArray(boolean[] values) {
+        JSONArray array = new JSONArray();
+        for (boolean value : values) array.put(value);
+        return array;
+    }
+
+    private JSONArray floatArrayToJSONArray(float[] values) {
+        JSONArray array = new JSONArray();
+        for (float value : values) {
+            try {
+                array.put(value);
+            } catch (JSONException e) {
+                AmplitudeLog.getLogger().e(TAG, String.format(
+                    "Error converting float %f to JSON: %s", value, e.toString()
+                ));
+            }
+        }
+        return array;
+    }
+
+    private JSONArray intArrayToJSONArray(int[] values) {
+        JSONArray array = new JSONArray();
+        for (int value : values) array.put(value);
+        return array;
+    }
+
+    private JSONArray longArrayToJSONArray(long[] values) {
+        JSONArray array = new JSONArray();
+        for (long value : values) array.put(value);
+        return array;
+    }
+
+    private JSONArray doubleArrayToJSONArray(double[] values) {
+        JSONArray array = new JSONArray();
+        for (double value : values) {
+            try {
+                array.put(value);
+            } catch (JSONException e) {
+                AmplitudeLog.getLogger().e(TAG, String.format(
+                    "Error converting double %d to JSON: %s", value, e.toString()
+                ));
+            }
+        }
+        return array;
+    }
+
     // Package private method - used by AmplitudeClient to convert setUserProperties to identify
     Identify setUserProperty(String property, Object value) {
         addToUserProperties(Constants.AMP_OP_SET, property, value);
@@ -198,13 +350,19 @@ public class Identify {
 
     // DEPRECATED - Object class is too general
     public Identify setOnce(String property, Object value) {
-        AmplitudeLog.getLogger().w(TAG, String.format("This version of setOnce is deprecated. Please use one with a different signature."));
+        AmplitudeLog.getLogger().w(
+            TAG,
+            "This version of setOnce is deprecated. Please use one with a different signature."
+        );
         return this;
     }
 
     // DEPRECATED - Object class is too general
     public Identify set(String property, Object value) {
-        AmplitudeLog.getLogger().w(TAG, String.format("This version of set is deprecated. Please use one with a different signature."));
+        AmplitudeLog.getLogger().w(
+            TAG,
+            "This version of set is deprecated. Please use one with a different signature."
+        );
         return this;
     }
 }

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -290,12 +290,6 @@ public class Identify {
         }
     }
 
-    private JSONArray stringArrayToJSONArray(String[] values) {
-        JSONArray array = new JSONArray();
-        for (String value : values) array.put(value);
-        return array;
-    }
-
     private JSONArray booleanArrayToJSONArray(boolean[] values) {
         JSONArray array = new JSONArray();
         for (boolean value : values) array.put(value);
@@ -309,7 +303,21 @@ public class Identify {
                 array.put(value);
             } catch (JSONException e) {
                 AmplitudeLog.getLogger().e(TAG, String.format(
-                    "Error converting float %f to JSON: %s", value, e.toString()
+                        "Error converting float %f to JSON: %s", value, e.toString()
+                ));
+            }
+        }
+        return array;
+    }
+
+    private JSONArray doubleArrayToJSONArray(double[] values) {
+        JSONArray array = new JSONArray();
+        for (double value : values) {
+            try {
+                array.put(value);
+            } catch (JSONException e) {
+                AmplitudeLog.getLogger().e(TAG, String.format(
+                        "Error converting double %d to JSON: %s", value, e.toString()
                 ));
             }
         }
@@ -328,17 +336,9 @@ public class Identify {
         return array;
     }
 
-    private JSONArray doubleArrayToJSONArray(double[] values) {
+    private JSONArray stringArrayToJSONArray(String[] values) {
         JSONArray array = new JSONArray();
-        for (double value : values) {
-            try {
-                array.put(value);
-            } catch (JSONException e) {
-                AmplitudeLog.getLogger().e(TAG, String.format(
-                    "Error converting double %d to JSON: %s", value, e.toString()
-                ));
-            }
-        }
+        for (String value : values) array.put(value);
         return array;
     }
 

--- a/src/com/amplitude/api/Identify.java
+++ b/src/com/amplitude/api/Identify.java
@@ -48,13 +48,13 @@ public class Identify {
         return this;
     }
 
-    public Identify setOnce(String property, JSONArray value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+    public Identify setOnce(String property, JSONArray values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, values);
         return this;
     }
 
-    public Identify setOnce(String property, JSONObject value) {
-        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, value);
+    public Identify setOnce(String property, JSONObject values) {
+        addToUserProperties(Constants.AMP_OP_SET_ONCE, property, values);
         return this;
     }
 
@@ -120,13 +120,13 @@ public class Identify {
         return this;
     }
 
-    public Identify set(String property, JSONObject value) {
-        addToUserProperties(Constants.AMP_OP_SET, property, value);
+    public Identify set(String property, JSONObject values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, values);
         return this;
     }
 
-    public Identify set(String property, JSONArray value) {
-        addToUserProperties(Constants.AMP_OP_SET, property, value);
+    public Identify set(String property, JSONArray values) {
+        addToUserProperties(Constants.AMP_OP_SET, property, values);
         return this;
     }
 
@@ -187,6 +187,12 @@ public class Identify {
         return this;
     }
 
+    // Server-side we flatten dictionaries and apply add to each flattened proeprty
+    public Identify add(String property, JSONObject values) {
+        addToUserProperties(Constants.AMP_OP_ADD, property, values);
+        return this;
+    }
+
 
     // APPEND
     public Identify append(String property, boolean value) {
@@ -219,8 +225,14 @@ public class Identify {
         return this;
     }
 
-    public Identify append(String property, JSONArray value) {
-        addToUserProperties(Constants.AMP_OP_APPEND, property, value);
+    public Identify append(String property, JSONArray values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, values);
+        return this;
+    }
+
+    // Server-side we flatten dictionaries and apply append to each flattened property
+    public Identify append(String property, JSONObject values) {
+        addToUserProperties(Constants.AMP_OP_APPEND, property, values);
         return this;
     }
 

--- a/test/com/amplitude/api/IdentifyTest.java
+++ b/test/com/amplitude/api/IdentifyTest.java
@@ -1,5 +1,6 @@
 package com.amplitude.api;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -8,9 +9,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.util.LinkedList;
-import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -131,17 +129,14 @@ public class IdentifyTest extends BaseTest {
         String property4 = "long value";
         long value4 = 18l;
 
-        String property5 = "list value";
-        List<Integer> value5 = new LinkedList<Integer>();
-        value5.add(15);
-        value5.add(25);
-
-        String property6 = "array value";
-        int [] value6 = new int[]{1, 2, 3};
+        String property5 = "array value";
+        JSONArray value5 = new JSONArray();
+        value5.put(1);
+        value5.put(2);
+        value5.put(3);
 
         Identify identify = new Identify().append(property1, value1).append(property2, value2);
-        identify.append(property3, value3).append(property4, value4);
-        identify.append(property5, value5).append(property6, value6);
+        identify.append(property3, value3).append(property4, value4).append(property5, value5);
 
         // identify should ignore this since duplicate key
         identify.add(property1, value3);
@@ -149,7 +144,7 @@ public class IdentifyTest extends BaseTest {
         JSONObject expected = new JSONObject();
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
-        expectedOperations.put(property5, value5).put(property6, value6);
+        expectedOperations.put(property5, value5);
         expected.put(Constants.AMP_OP_APPEND, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
@@ -167,10 +162,10 @@ public class IdentifyTest extends BaseTest {
 
         String property4 = "json value";
 
-        String property5 = "list value";
-        List<Integer> value5 = new LinkedList<Integer>();
-        value5.add(15);
-        value5.add(25);
+        String property5 = "array value";
+        JSONArray value5 = new JSONArray();
+        value5.put(15);
+        value5.put(25);
 
         Identify identify = new Identify().setOnce(property1, value1).add(property2, value2);
         identify.set(property3, value3).unset(property4).append(property5, value5);

--- a/test/com/amplitude/api/IdentifyTest.java
+++ b/test/com/amplitude/api/IdentifyTest.java
@@ -48,8 +48,13 @@ public class IdentifyTest extends BaseTest {
         String property4 = "json value";
         JSONObject value4 = new JSONObject();
 
+        String property5 = "boolean array";
+        boolean[] value5 = new boolean[]{true, true, false};
+        JSONArray value5Expected = new JSONArray();
+        for (boolean value : value5) value5Expected.put(value);
+
         Identify identify = new Identify().set(property1, value1).set(property2, value2);
-        identify.set(property3, value3).set(property4, value4);
+        identify.set(property3, value3).set(property4, value4).set(property5, value5);
 
         // identify should ignore this since duplicate key
         identify.set(property1, value3);
@@ -57,6 +62,7 @@ public class IdentifyTest extends BaseTest {
         JSONObject expected = new JSONObject();
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
+        expectedOperations.put(property5, value5Expected);
         expected.put(Constants.AMP_OP_SET, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
@@ -75,8 +81,13 @@ public class IdentifyTest extends BaseTest {
         String property4 = "json value";
         JSONObject value4 = new JSONObject();
 
+        String property5 = "double array";
+        double[] value5 = new double[]{1.2, 2.3, 3.4};
+        JSONArray value5Expected = new JSONArray();
+        for (double value : value5) value5Expected.put(value);
+
         Identify identify = new Identify().setOnce(property1, value1).setOnce(property2, value2);
-        identify.setOnce(property3, value3).setOnce(property4, value4);
+        identify.setOnce(property3, value3).setOnce(property4, value4).setOnce(property5, value5);
 
         // identify should ignore this since duplicate key
         identify.setOnce(property1, value3);
@@ -84,6 +95,7 @@ public class IdentifyTest extends BaseTest {
         JSONObject expected = new JSONObject();
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
+        expectedOperations.put(property5, value5Expected);
         expected.put(Constants.AMP_OP_SET_ONCE, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
@@ -102,8 +114,11 @@ public class IdentifyTest extends BaseTest {
         String property4 = "long value";
         long value4 = 18l;
 
+        String property5 = "string value";
+        String value5 = "19";
+
         Identify identify = new Identify().add(property1, value1).add(property2, value2);
-        identify.add(property3, value3).add(property4, value4);
+        identify.add(property3, value3).add(property4, value4).add(property5, value5);
 
         // identify should ignore this since duplicate key
         identify.add(property1, value3);
@@ -111,6 +126,7 @@ public class IdentifyTest extends BaseTest {
         JSONObject expected = new JSONObject();
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
+        expectedOperations.put(property5, value5);
         expected.put(Constants.AMP_OP_ADD, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
@@ -135,8 +151,30 @@ public class IdentifyTest extends BaseTest {
         value5.put(2);
         value5.put(3);
 
+        String property6 = "float array";
+        float[] value6 = new float[]{(float)1.2, (float)2.3, (float)3.4, (float)4.5};
+        JSONArray value6Expected = new JSONArray();
+        for (float value : value6) value6Expected.put(value);
+
+        String property7 = "int array";
+        int[] value7 = new int[]{10, 12, 14, 17};
+        JSONArray value7Expected = new JSONArray();
+        for (int value : value7) value7Expected.put(value);
+
+        String property8 = "long array";
+        long[] value8 = new long[]{20, 22, 24, 27};
+        JSONArray value8Expected = new JSONArray();
+        for (long value : value8) value8Expected.put(value);
+
+        String property9 = "string array";
+        String[] value9 = new String[]{"test1", "test2", "test3"};
+        JSONArray value9Expected = new JSONArray();
+        for (String value : value9) value9Expected.put(value);
+
         Identify identify = new Identify().append(property1, value1).append(property2, value2);
         identify.append(property3, value3).append(property4, value4).append(property5, value5);
+        identify.append(property6, value6).append(property7, value7).append(property8, value8);
+        identify.append(property9, value9);
 
         // identify should ignore this since duplicate key
         identify.add(property1, value3);
@@ -144,7 +182,9 @@ public class IdentifyTest extends BaseTest {
         JSONObject expected = new JSONObject();
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
-        expectedOperations.put(property5, value5);
+        expectedOperations.put(property5, value5).put(property6, value6Expected);
+        expectedOperations.put(property7, value7Expected).put(property8, value8Expected);
+        expectedOperations.put(property9, value9Expected);
         expected.put(Constants.AMP_OP_APPEND, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }

--- a/test/com/amplitude/api/IdentifyTest.java
+++ b/test/com/amplitude/api/IdentifyTest.java
@@ -9,6 +9,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -101,7 +104,6 @@ public class IdentifyTest extends BaseTest {
         String property4 = "long value";
         long value4 = 18l;
 
-
         Identify identify = new Identify().add(property1, value1).add(property2, value2);
         identify.add(property3, value3).add(property4, value4);
 
@@ -112,6 +114,43 @@ public class IdentifyTest extends BaseTest {
         JSONObject expectedOperations = new JSONObject().put(property1, value1);
         expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
         expected.put(Constants.AMP_OP_ADD, expectedOperations);
+        assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
+    }
+
+    @Test
+    public void testAppendProperty() throws JSONException {
+        String property1 = "int value";
+        int value1 = 5;
+
+        String property2 = "double value";
+        double value2 = 0.123;
+
+        String property3 = "float value";
+        double value3 = 0.625; // floats are actually promoted to long in JSONObject
+
+        String property4 = "long value";
+        long value4 = 18l;
+
+        String property5 = "list value";
+        List<Integer> value5 = new LinkedList<Integer>();
+        value5.add(15);
+        value5.add(25);
+
+        String property6 = "array value";
+        int [] value6 = new int[]{1, 2, 3};
+
+        Identify identify = new Identify().append(property1, value1).append(property2, value2);
+        identify.append(property3, value3).append(property4, value4);
+        identify.append(property5, value5).append(property6, value6);
+
+        // identify should ignore this since duplicate key
+        identify.add(property1, value3);
+
+        JSONObject expected = new JSONObject();
+        JSONObject expectedOperations = new JSONObject().put(property1, value1);
+        expectedOperations.put(property2, value2).put(property3, value3).put(property4, value4);
+        expectedOperations.put(property5, value5).put(property6, value6);
+        expected.put(Constants.AMP_OP_APPEND, expectedOperations);
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
 
@@ -128,8 +167,13 @@ public class IdentifyTest extends BaseTest {
 
         String property4 = "json value";
 
+        String property5 = "list value";
+        List<Integer> value5 = new LinkedList<Integer>();
+        value5.add(15);
+        value5.add(25);
+
         Identify identify = new Identify().setOnce(property1, value1).add(property2, value2);
-        identify.set(property3, value3).unset(property4);
+        identify.set(property3, value3).unset(property4).append(property5, value5);
 
         // identify should ignore this since duplicate key
         identify.set(property4, value3);
@@ -139,6 +183,7 @@ public class IdentifyTest extends BaseTest {
         expected.put(Constants.AMP_OP_ADD, new JSONObject().put(property2, value2));
         expected.put(Constants.AMP_OP_SET, new JSONObject().put(property3, value3));
         expected.put(Constants.AMP_OP_UNSET, new JSONObject().put(property4, "-"));
+        expected.put(Constants.AMP_OP_APPEND, new JSONObject().put(property5, value5));
         assertTrue(compareJSONObjects(expected, identify.userPropertiesOperations));
     }
 


### PR DESCRIPTION
1. Add $append operation
2. Deprecate existing Identify.set and Identify.setOnce that allow Object type inputs for the value. We explicitly only want people to pass in String, boolean, float, int, double, long, JSONArray, JSONObject.
3. In translating setUserProperties calls to an Identify object, we still want some form of set that allows Object type inputs, so I added a package private Identify.setUserProperty. I was also considering adding some sort of Identify.initWithUserProperties(JSONObject) method, but we would still want to do duplicate checking, so it makes sense just to keep the set.

PTAL at the API changes @curtisliu 