### PR TITLE
Allow multiple apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add support for logging events to multiple Amplitude apps. See [Readme](https://github.com/amplitude/Amplitude-Android#logging-events-to-multiple-amplitude-apps) for details.
+
 ## 2.5.0 (January 15, 2016)
 
 * Add ability to clear all user properties.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,44 @@ String userId = getUserIdResponse.getUserId();
 Amplitude.getInstance().logRevenue("com.company.productid", 1, 3.99, purchaseToken, userId);
 ```
 
+# Logging Events to Multiple Amplitude Apps #
+
+The Amplitude Android SDK supports logging events to multiple Amplitude apps (multiple API keys). If you want to log events to multiple Amplitude apps, you will want to use separate instances for each Amplitude app. Each instance will allow for completely independent apiKeys, userIds, deviceIds, and settings.
+
+You will need to assign a name to each Amplitude app / instance, and use that name consistently when fetching that instance to call functions. You could use names such as `app1`, `app2`, or more descriptive names such as `prod_app`, `test_app`. Note these names do not need to correspond to the names of your apps in the Amplitude dashboards. The only thing that matters is that each instance is initialized with the correct apiKey.
+
+You can fetch each instance by name by calling `Amplitude.getInstance("INSTANCE_NAME")`.
+
+Here's an example of how to set up and log events to two separate apps:
+
+```java
+Amplitude.getInstance("original_app").initialize(this, "12345");
+Amplitude.getInstance("new_app").initialize(this, "67890");
+
+Amplitude.getInstance("original_app").setUserId("joe@gmail.com");
+Amplitude.getInstance("original_app").logEvent("Clicked");
+
+Identify identify = new Identify().add("karma", 1);
+Amplitude.getInstance("new_app").identify(identify);
+Amplitude.getInstance("new_app").logEvent("Viewed Home Page");
+```
+
+**IMPORTANT - Upgrading from single app to multiple apps:** if you were tracking users with a single app before v2.6.0, you might be wondering what will happen to returning users (users who already have a deviceId and/or userId). By default any instance you initialize will inherit existing deviceId and userId values from before v2.6.0. This will maintain continuity in your existing app, and those users will appear as returning users. In your new app they will still appear as new users. If you wish to initialize an instance that does not inherit existing deviceId and userId values from before v2.6.0, you can set argument `newBlankInstance` to `true` when calling `initialize`.
+
+In the above example, both `original_app` and `new_app` inherit existing deviceId and userId values. Below is an example of how to set up and log events to two separate apps, with `new_app` starting from a clean slate (not inheriting existing deviceId and userId values):
+
+```java
+Amplitude.getInstance("original_app").initialize(this, "12345");
+Amplitude.getInstance("new_app").initialize(this, "67890", null, true); // newBlankInstance is set to true
+
+Amplitude.getInstance("original_app").setUserId("joe@gmail.com");
+Amplitude.getInstance("original_app").logEvent("Clicked");
+
+Identify identify = new Identify().add("karma", 1);
+Amplitude.getInstance("new_app").identify(identify);
+Amplitude.getInstance("new_app").logEvent("Viewed Home Page");
+```
+
 # Fine-grained location tracking #
 
 Amplitude can access the Android location service (if possible) to add the specific coordinates (longitude and latitude) where an event is logged. This behaviour is enabled by default, but can be adjusted calling the following methods *after* initializing:

--- a/src/com/amplitude/api/Amplitude.java
+++ b/src/com/amplitude/api/Amplitude.java
@@ -1,13 +1,31 @@
 package com.amplitude.api;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import org.json.JSONObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Amplitude {
 
-    public static AmplitudeClient getInstance() {
-        return AmplitudeClient.getInstance();
+    private static final Map<String, AmplitudeClient> instances = new HashMap<String, AmplitudeClient>();
+
+    public static synchronized AmplitudeClient getInstance() {
+        return getInstance(null);
+    }
+
+    public static synchronized AmplitudeClient getInstance(String instance) {
+        if (TextUtils.isEmpty(instance)) {
+            instance = Constants.DEFAULT_INSTANCE;
+        }
+
+        if (!instances.containsKey(instance)) {
+            instances.put(instance, new AmplitudeClient());
+        }
+
+        return instances.get(instance);
     }
 
     @Deprecated

--- a/src/com/amplitude/api/Amplitude.java
+++ b/src/com/amplitude/api/Amplitude.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class Amplitude {
 
-    private static final Map<String, AmplitudeClient> instances = new HashMap<String, AmplitudeClient>();
+    static final Map<String, AmplitudeClient> instances = new HashMap<String, AmplitudeClient>();
 
     public static synchronized AmplitudeClient getInstance() {
         return getInstance(null);
@@ -21,11 +21,12 @@ public class Amplitude {
             instance = Constants.DEFAULT_INSTANCE;
         }
 
-        if (!instances.containsKey(instance)) {
-            instances.put(instance, new AmplitudeClient());
+        AmplitudeClient client = instances.get(instance);
+        if (client == null) {
+            client = new AmplitudeClient();
+            instances.put(instance, client);
         }
-
-        return instances.get(instance);
+        return client;
     }
 
     @Deprecated

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -93,7 +93,6 @@ public class AmplitudeClient {
         }
 
         AmplitudeClient.upgradePrefs(context);
-        AmplitudeClient.upgradeDeviceIdToDB(context);
 
         if (TextUtils.isEmpty(apiKey)) {
             logger.e(TAG, "Argument apiKey cannot be null or blank in initialize()");
@@ -106,6 +105,7 @@ public class AmplitudeClient {
             this.apiKeySuffix = apiKey.substring(
                     0, Math.min(Constants.API_KEY_SUFFIX_LENGTH, apiKey.length())
             );
+            AmplitudeClient.upgradeDeviceIdToDB(context, null, this.apiKeySuffix);
             initializeDeviceInfo();
             SharedPreferences preferences = context.getSharedPreferences(
                     getSharedPreferencesName(), Context.MODE_PRIVATE);
@@ -1202,11 +1202,11 @@ public class AmplitudeClient {
      * This logic needs to remain in place for quite a long time. It was first introduced in
      * August 2015 in version 1.8.0.
      */
-    static boolean upgradeDeviceIdToDB(Context context) {
-        return upgradeDeviceIdToDB(context, null);
-    }
+//    static boolean upgradeDeviceIdToDB(Context context) {
+//        return upgradeDeviceIdToDB(context, null);
+//    }
 
-    static boolean upgradeDeviceIdToDB(Context context, String sourcePkgName) {
+    static boolean upgradeDeviceIdToDB(Context context, String sourcePkgName, String apiKeySuffix) {
         if (sourcePkgName == null) {
             sourcePkgName = Constants.PACKAGE_NAME;
         }
@@ -1217,7 +1217,7 @@ public class AmplitudeClient {
 
         String deviceId = preferences.getString(Constants.PREFKEY_DEVICE_ID, null);
         if (!TextUtils.isEmpty(deviceId)) {
-            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
             dbHelper.insertOrReplaceKeyValue(DEVICE_ID_KEY, deviceId);
 
             // remove device id from sharedPrefs so that this upgrade occurs only once

--- a/src/com/amplitude/api/AmplitudeUtils.java
+++ b/src/com/amplitude/api/AmplitudeUtils.java
@@ -1,0 +1,28 @@
+package com.amplitude.api;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Created by danieljih on 2/2/16.
+ */
+public class AmplitudeUtils {
+
+    public static void copyFile(File src, File dst) throws IOException {
+        InputStream in = new FileInputStream(src);
+        OutputStream out = new FileOutputStream(dst);
+
+        // Transfer bytes from in to out
+        byte[] buf = new byte[1024];
+        int len;
+        while ((len = in.read(buf)) > 0) {
+            out.write(buf, 0, len);
+        }
+        in.close();
+        out.close();
+    }
+}

--- a/src/com/amplitude/api/Constants.java
+++ b/src/com/amplitude/api/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
     public static final String DATABASE_NAME = PACKAGE_NAME;
     public static final int DATABASE_VERSION = 3;
 
+    public static final String DEFAULT_INSTANCE = "$defaultInstance";
+
     public static final int EVENT_UPLOAD_THRESHOLD = 30;
     public static final int EVENT_UPLOAD_MAX_BATCH_SIZE = 100;
     public static final int EVENT_MAX_COUNT = 1000;
@@ -23,6 +25,7 @@ public class Constants {
     public static final long MIN_TIME_BETWEEN_SESSIONS_MILLIS = 5 * 60 * 1000; // 5m
     public static final long SESSION_TIMEOUT_MILLIS = 30 * 60 * 1000; // 30m
     public static final int MAX_STRING_LENGTH = 1024;
+    public static final int API_KEY_SUFFIX_LENGTH = 6;
 
     public static final String SHARED_PREFERENCES_NAME_PREFIX = PACKAGE_NAME;
     public static final String PREFKEY_LAST_EVENT_ID = PACKAGE_NAME + ".lastEventId";

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 class DatabaseHelper extends SQLiteOpenHelper {
 
-    private static final Map<String, DatabaseHelper> instances =
+    static final Map<String, DatabaseHelper> instances =
             new HashMap<String, DatabaseHelper>();
 
     private static final String TAG = "com.amplitude.api.DatabaseHelper";
@@ -70,8 +70,8 @@ class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     private DatabaseHelper(Context context, String apiKeySuffix) {
-        super(context, Constants.DATABASE_NAME + apiKeySuffix, null, Constants.DATABASE_VERSION);
-        file = context.getDatabasePath(Constants.DATABASE_NAME + apiKeySuffix);
+        super(context, Constants.DATABASE_NAME, null, Constants.DATABASE_VERSION);
+        file = context.getDatabasePath(Constants.DATABASE_NAME);
     }
 
     @Override

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -27,13 +27,14 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
-public class AmplitudeTest extends BaseTest {
+public class AmplitudeClientTest extends BaseTest {
 
     private String generateStringWithLength(int length, char c) {
         if (length < 0) return "";
@@ -50,6 +51,24 @@ public class AmplitudeTest extends BaseTest {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
+    }
+
+    @Test
+    public void testGetInstance() {
+        AmplitudeClient a = Amplitude.getInstance();
+//        a.logEvent("test");
+
+        AmplitudeClient b = Amplitude.getInstance("");
+        AmplitudeClient c = Amplitude.getInstance(null);
+        AmplitudeClient d = Amplitude.getInstance("$defaultInstance");
+        AmplitudeClient e = Amplitude.getInstance("new app");
+
+        assertEquals(a, b);
+        assertEquals(b, c);
+        assertEquals(c, d);
+        assertNotSame(d, e);
+
+        a.initialize(context, "1cc2c1978ebab0f6451112a8f5df4f4e");
     }
 
     @Test

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -27,7 +27,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -51,24 +50,6 @@ public class AmplitudeClientTest extends BaseTest {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-    }
-
-    @Test
-    public void testGetInstance() {
-        AmplitudeClient a = Amplitude.getInstance();
-//        a.logEvent("test");
-
-        AmplitudeClient b = Amplitude.getInstance("");
-        AmplitudeClient c = Amplitude.getInstance(null);
-        AmplitudeClient d = Amplitude.getInstance("$defaultInstance");
-        AmplitudeClient e = Amplitude.getInstance("new app");
-
-        assertEquals(a, b);
-        assertEquals(b, c);
-        assertEquals(c, d);
-        assertNotSame(d, e);
-
-        a.initialize(context, "1cc2c1978ebab0f6451112a8f5df4f4e");
     }
 
     @Test
@@ -289,7 +270,6 @@ public class AmplitudeClientTest extends BaseTest {
                 deviceId,
                 dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY)
         );
-
     }
 
     @Test
@@ -403,7 +383,7 @@ public class AmplitudeClientTest extends BaseTest {
         }
 
         // send response and check that remove events works properly
-        runRequest();
+        runRequest(amplitude);
         looper.runToEndOfTasks();
         looper.runToEndOfTasks();
         assertEquals(getUnsentEventCount(), 0);
@@ -457,7 +437,7 @@ public class AmplitudeClientTest extends BaseTest {
         ));
 
         // send response and check that remove events works properly
-        runRequest();
+        runRequest(amplitude);
         looper.runToEndOfTasks();
         looper.runToEndOfTasks();
         assertEquals(getUnsentEventCount(), 0);
@@ -498,7 +478,7 @@ public class AmplitudeClientTest extends BaseTest {
         ));
 
         // send response and check that remove events works properly
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
         assertEquals(events.length(), 2);
         assertEquals(events.optJSONObject(0).optString("event_type"), "test_event");
@@ -538,7 +518,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(getUnsentIdentifyCount(), 3);
         assertEquals(amplitude.getLastIdentifyId(), 3);
 
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
         assertEquals(events.length(), 7);
 
@@ -646,7 +626,7 @@ public class AmplitudeClientTest extends BaseTest {
         expectedIdentify2.put(Constants.AMP_OP_ADD, new JSONObject().put("photo_count", 2));
 
         // send response and check that merging events correctly ordered events
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
         assertEquals(events.length(), 4);
         assertEquals(events.optJSONObject(0).optString("event_type"), "test_event1");
@@ -690,7 +670,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(getUnsentEventCount(), Constants.EVENT_UPLOAD_THRESHOLD);
         assertEquals(getUnsentIdentifyCount(), 2);
 
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
         for (int i = 0; i < events.length(); i++) {
             assertEquals(events.optJSONObject(i).optString("event_type"), "test_event" + i);
@@ -766,7 +746,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals("RECEIPT", apiProps.optString("receipt"));
         assertEquals("SIG", apiProps.optString("receiptSig"));
 
-        assertNotNull(runRequest());
+        assertNotNull(runRequest(amplitude));
     }
 
     @Test
@@ -997,7 +977,7 @@ public class AmplitudeClientTest extends BaseTest {
 
         looper.runToEndOfTasks();
         looper.runToEndOfTasks();
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
 
         assertEquals(events.optJSONObject(0).optString("event_type"), "test");
@@ -1036,7 +1016,7 @@ public class AmplitudeClientTest extends BaseTest {
 
         amplitude.setOffline(false);
         looper.runToEndOfTasks();
-        RecordedRequest request = runRequest();
+        RecordedRequest request = runRequest(amplitude);
         JSONArray events = getEventsFromRequest(request);
         looper.runToEndOfTasks();
 

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -121,7 +121,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testSetDeviceId() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         assertNull(amplitude.getDeviceId());
         looper.runToEndOfTasks();
@@ -247,7 +247,7 @@ public class AmplitudeClientTest extends BaseTest {
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
 
         assertNull(amplitude.getDeviceId());
-        DatabaseHelper.getDatabaseHelper(context).insertOrReplaceKeyValue(
+        DatabaseHelper.getDatabaseHelper(context, apiKeySuffix).insertOrReplaceKeyValue(
                 AmplitudeClient.DEVICE_ID_KEY,
                 deviceId
         );
@@ -268,9 +268,10 @@ public class AmplitudeClientTest extends BaseTest {
         looper.getScheduler().advanceToLastPostedRunnable();
         String deviceId = amplitude.getDeviceId();
         assertTrue(deviceId.endsWith("R"));
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         assertEquals(
                 deviceId,
-                DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
+                dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY)
         );
     }
 
@@ -283,9 +284,10 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(37, amplitude.getDeviceId().length());
         String deviceId = amplitude.getDeviceId();
         assertTrue(deviceId.endsWith("R"));
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         assertEquals(
                 deviceId,
-                DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
+                dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY)
         );
 
     }
@@ -622,7 +624,7 @@ public class AmplitudeClientTest extends BaseTest {
         event.remove("sequence_number");
         event.remove("event_id");
         // delete event from db and reinsert modified event
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         dbHelper.removeEvent(1);
         dbHelper.addEvent(event.toString());
         amplitude.uploadingCurrently.set(false);
@@ -1012,7 +1014,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testAutoIncrementSequenceNumber() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         int limit = 10;
         for (int i = 0; i < limit; i++) {
             assertEquals(amplitude.getNextSequenceNumber(), i+1);
@@ -1049,7 +1051,7 @@ public class AmplitudeClientTest extends BaseTest {
         clock.setTimestamps(timestamps);
         Robolectric.getForegroundThreadScheduler().advanceTo(1);
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         int eventMaxCount = 3;
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         amplitude.setEventMaxCount(eventMaxCount).setOffline(true);
@@ -1085,7 +1087,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testTruncateEventsQueues() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         int eventMaxCount = 50;
         assertTrue(eventMaxCount > Constants.EVENT_REMOVE_BATCH_SIZE);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
@@ -1104,7 +1106,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testTruncateEventsQueuesWithOneEvent() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
         int eventMaxCount = 1;
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         amplitude.setEventMaxCount(eventMaxCount).setOffline(true);

--- a/test/com/amplitude/api/AmplitudeTest.java
+++ b/test/com/amplitude/api/AmplitudeTest.java
@@ -1,0 +1,136 @@
+package com.amplitude.api;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AmplitudeTest extends BaseTest {
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    public void testGetInstance() {
+        AmplitudeClient a = Amplitude.getInstance();
+        AmplitudeClient b = Amplitude.getInstance("");
+        AmplitudeClient c = Amplitude.getInstance(null);
+        AmplitudeClient d = Amplitude.getInstance(Constants.DEFAULT_INSTANCE);
+        AmplitudeClient e = Amplitude.getInstance("app1");
+        AmplitudeClient f = Amplitude.getInstance("app2");
+
+        assertSame(a, b);
+        assertSame(b, c);
+        assertSame(c, d);
+        assertSame(d, Amplitude.getInstance());
+        assertNotSame(d, e);
+        assertSame(e, Amplitude.getInstance("app1"));
+        assertNotSame(e, f);
+        assertSame(f, Amplitude.getInstance("app2"));
+
+        assertTrue(Amplitude.instances.size() == 3);
+        assertTrue(Amplitude.instances.containsKey(Constants.DEFAULT_INSTANCE));
+        assertTrue(Amplitude.instances.containsKey("app1"));
+        assertTrue(Amplitude.instances.containsKey("app2"));
+    }
+
+    @Test
+    public void testSeparateInstancesLogEventsSeparately() {
+        String deviceId = "testDeviceId";
+        String event1 = "testEvent1";
+        String identify1 = "testIdentify1";
+        String identify2 = "testIdentify2";
+
+        String newApiKey1 = "1234567890";
+        String newApiKeySuffix1 = newApiKey1.substring(0, 6);
+        String newApiKey2 = "0987654321";
+        String newApiKeySuffix2 = newApiKey2.substring(0, 6);
+
+        // Setup existing Databasefile
+        DatabaseHelper oldDbHelper = DatabaseHelper.getDatabaseHelper(context);
+        oldDbHelper.insertOrReplaceKeyValue("device_id", deviceId);
+        oldDbHelper.insertOrReplaceKeyLongValue("sequence_number", 1000L);
+        oldDbHelper.addEvent(event1);
+        oldDbHelper.addIdentify(identify1);
+        oldDbHelper.addIdentify(identify2);
+
+        File oldDbFile = context.getDatabasePath(Constants.DATABASE_NAME);
+        assertTrue(oldDbFile.exists());
+        File newDbFile1 = context.getDatabasePath(Constants.DATABASE_NAME + "_" + newApiKeySuffix1);
+        assertFalse(newDbFile1.exists());
+        File newDbFile2 = context.getDatabasePath(Constants.DATABASE_NAME + "_" + newApiKeySuffix2);
+        assertFalse(newDbFile2.exists());
+
+        // init first new app and do database file migration
+        Amplitude.getInstance("app1").initialize(context, newApiKey1);
+        assertTrue(newDbFile1.exists());
+        assertFalse(newDbFile2.exists());
+
+        DatabaseHelper newDbHelper1 = DatabaseHelper.getDatabaseHelper(context, newApiKeySuffix1);
+        assertEquals(newDbHelper1.getValue("device_id"), deviceId);
+        assertEquals(newDbHelper1.getLongValue("sequence_number").longValue(), 1000L);
+        assertEquals(newDbHelper1.getEventCount(), 1);
+        assertEquals(newDbHelper1.getIdentifyCount(), 2);
+
+        // init second new app without database file migration
+        Amplitude.getInstance("app2").initialize(context, newApiKey2, null, true);
+        assertTrue(newDbFile1.exists());
+        assertFalse(newDbFile2.exists());
+
+        // database file will be created once app2 goes through deviceId init process
+        Shadows.shadowOf(Amplitude.getInstance("app2").logThread.getLooper()).runToEndOfTasks();
+        assertTrue(newDbFile2.exists());
+        DatabaseHelper newDbHelper2 = DatabaseHelper.getDatabaseHelper(context, newApiKeySuffix2);
+        assertFalse(newDbHelper2.getValue("device_id").equals(deviceId));
+        assertEquals(newDbHelper2.getEventCount(), 0);
+        assertEquals(newDbHelper2.getIdentifyCount(), 0);
+
+        // verify existing database still intact
+        assertTrue(oldDbFile.exists());
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        assertEquals(oldDbHelper.getLongValue("sequence_number").longValue(), 1000L);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        // verify both apps can modify their database indepdently and not affect old database
+        newDbHelper1.insertOrReplaceKeyValue("device_id", "fakeDeviceId");
+        assertEquals(newDbHelper1.getValue("device_id"), "fakeDeviceId");
+        assertFalse(newDbHelper2.getValue("device_id").equals("fakeDeviceId"));
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        newDbHelper1.addIdentify("testIdentify3");
+        assertEquals(newDbHelper1.getIdentifyCount(), 3);
+        assertEquals(newDbHelper2.getIdentifyCount(), 0);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        // verify modifying new database does not affect old database
+        newDbHelper2.insertOrReplaceKeyValue("device_id", "brandNewDeviceId");
+        assertEquals(newDbHelper1.getValue("device_id"), "fakeDeviceId");
+        assertEquals(newDbHelper2.getValue("device_id"), "brandNewDeviceId");
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        newDbHelper2.addEvent("testEvent2");
+        newDbHelper2.addEvent("testEvent3");
+        assertEquals(newDbHelper1.getEventCount(), 1);
+        assertEquals(newDbHelper2.getEventCount(), 2);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+    }
+}

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -74,6 +74,7 @@ public class BaseTest {
         // Clear the database helper for each test. Better to have isolation.
         // See https://github.com/robolectric/robolectric/issues/569
         // and https://github.com/robolectric/robolectric/issues/1622
+        Amplitude.instances.clear();
         DatabaseHelper.instances.clear();
 
         if (withServer) {
@@ -109,10 +110,11 @@ public class BaseTest {
             server.shutdown();
         }
 
+        Amplitude.instances.clear();
         DatabaseHelper.instances.clear();
     }
 
-    public RecordedRequest runRequest() {
+    public RecordedRequest runRequest(AmplitudeClient amplitude) {
         server.enqueue(new MockResponse().setBody("success"));
         ShadowLooper httplooper = Shadows.shadowOf(amplitude.httpThread.getLooper());
         httplooper.runToEndOfTasks();
@@ -130,7 +132,7 @@ public class BaseTest {
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
 
-        return runRequest();
+        return runRequest(amplitude);
     }
 
     public RecordedRequest sendIdentify(AmplitudeClient amplitude, Identify identify) {
@@ -139,7 +141,7 @@ public class BaseTest {
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
 
-        return runRequest();
+        return runRequest(amplitude);
     }
 
     public long getUnsentEventCount() {

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -55,6 +55,8 @@ public class BaseTest {
     protected Context context;
     protected MockWebServer server;
     protected MockClock clock;
+    protected String apiKey = "1cc2c1978ebab0f6451112a8f5df4f4e";
+    protected String apiKeySuffix = apiKey.substring(0, 6);
 
     public void setUp() throws Exception {
         setUp(true);
@@ -72,7 +74,7 @@ public class BaseTest {
         // Clear the database helper for each test. Better to have isolation.
         // See https://github.com/robolectric/robolectric/issues/569
         // and https://github.com/robolectric/robolectric/issues/1622
-        DatabaseHelper.instance = null;
+        DatabaseHelper.instances.clear();
 
         if (withServer) {
             server = new MockWebServer();
@@ -88,7 +90,7 @@ public class BaseTest {
             // this sometimes deadlocks with lock contention by logThread and httpThread for
             // a ShadowWrangler instance and the ShadowLooper class
             // Might be a sign of a bug, or just Robolectric's bug.
-            amplitude.initialize(context, "1cc2c1978ebab0f6451112a8f5df4f4e");
+            amplitude.initialize(context, apiKey);
         }
 
         if (server != null) {
@@ -107,7 +109,7 @@ public class BaseTest {
             server.shutdown();
         }
 
-        DatabaseHelper.instance = null;
+        DatabaseHelper.instances.clear();
     }
 
     public RecordedRequest runRequest() {
@@ -141,11 +143,11 @@ public class BaseTest {
     }
 
     public long getUnsentEventCount() {
-        return DatabaseHelper.getDatabaseHelper(context).getEventCount();
+        return DatabaseHelper.getDatabaseHelper(context, apiKeySuffix).getEventCount();
     }
 
     public long getUnsentIdentifyCount() {
-        return DatabaseHelper.getDatabaseHelper(context).getIdentifyCount();
+        return DatabaseHelper.getDatabaseHelper(context, apiKeySuffix).getIdentifyCount();
     }
 
 
@@ -169,7 +171,7 @@ public class BaseTest {
 
     public JSONArray getUnsentEventsFromTable(String table, int limit) {
         try {
-            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
             List<JSONObject> events = table.equals(DatabaseHelper.IDENTIFY_TABLE_NAME) ?
                     dbHelper.getIdentifys(-1, -1) : dbHelper.getEvents(-1, -1);
 
@@ -196,7 +198,7 @@ public class BaseTest {
 
     public JSONObject getLastEventFromTable(String table) {
         try {
-            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
             List<JSONObject> events = table.equals(DatabaseHelper.IDENTIFY_TABLE_NAME) ?
                     dbHelper.getIdentifys(-1, -1) : dbHelper.getEvents(-1, -1);
             return events.get(events.size() - 1);

--- a/test/com/amplitude/api/DatabaseHelperTest.java
+++ b/test/com/amplitude/api/DatabaseHelperTest.java
@@ -12,6 +12,9 @@ import org.robolectric.annotation.Config;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
@@ -23,7 +26,7 @@ public class DatabaseHelperTest extends BaseTest {
     @Before
     public void setUp() throws Exception {
         super.setUp(false);
-        dbInstance = DatabaseHelper.getDatabaseHelper(context);
+        dbInstance = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
     }
 
     @After
@@ -65,6 +68,17 @@ public class DatabaseHelperTest extends BaseTest {
     }
 
     protected Long getLongValue(String key) { return dbInstance.getLongValue(key); }
+
+    @Test
+    public void testGetDatabaseHelper() {
+        assertNull(DatabaseHelper.getDatabaseHelper(context, null));
+        assertNull(DatabaseHelper.getDatabaseHelper(context, ""));
+        DatabaseHelper a = DatabaseHelper.getDatabaseHelper(context, "a");
+        DatabaseHelper b = DatabaseHelper.getDatabaseHelper(context, "b");
+        assertNotSame(a, b);
+        assertSame(a, DatabaseHelper.getDatabaseHelper(context, "a"));
+        assertSame(b, DatabaseHelper.getDatabaseHelper(context, "b"));
+    }
 
     @Test
     public void testCreate() {

--- a/test/com/amplitude/api/InitializeTest.java
+++ b/test/com/amplitude/api/InitializeTest.java
@@ -4,15 +4,21 @@ import android.content.Context;
 
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import org.json.JSONException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 
+import java.io.File;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -20,7 +26,6 @@ public class InitializeTest extends BaseTest {
 
     @Before
     public void setUp() throws Exception {
-        amplitude = Amplitude.getInstance();
         super.setUp();
     }
 
@@ -47,5 +52,104 @@ public class InitializeTest extends BaseTest {
         // Test that events are logged.
         RecordedRequest request = sendEvent(amplitude, "init_test_event", null);
         assertNotNull(request);
+    }
+
+    @Test
+    public void testMigrateExistingDatabaseFile() throws JSONException {
+        String deviceId = "testDeviceId";
+        String event1 = "testEvent1";
+        String identify1 = "testIdentify1";
+        String identify2 = "testIdentify2";
+
+        String newApiKey = "1234567890";
+        String newApiKeySuffix = newApiKey.substring(0, 6);
+
+        // Setup existing Databasefile
+        DatabaseHelper oldDbHelper = DatabaseHelper.getDatabaseHelper(context);
+        oldDbHelper.insertOrReplaceKeyValue("device_id", deviceId);
+        oldDbHelper.insertOrReplaceKeyLongValue("sequence_number", 1000L);
+        oldDbHelper.addEvent(event1);
+        oldDbHelper.addIdentify(identify1);
+        oldDbHelper.addIdentify(identify2);
+
+        File oldDbFile = context.getDatabasePath(Constants.DATABASE_NAME);
+        assertTrue(oldDbFile.exists());
+        File newDbFile = context.getDatabasePath(Constants.DATABASE_NAME + "_" + newApiKeySuffix);
+        assertFalse(newDbFile.exists());
+
+        // Migrate with init
+        Amplitude.getInstance("new app").initialize(context, newApiKey);
+        assertTrue(newDbFile.exists());
+        DatabaseHelper newDbHelper = DatabaseHelper.getDatabaseHelper(context, newApiKeySuffix);
+        assertEquals(newDbHelper.getValue("device_id"), deviceId);
+        assertEquals(newDbHelper.getLongValue("sequence_number").longValue(), 1000L);
+        assertEquals(newDbHelper.getEventCount(), 1);
+        assertEquals(newDbHelper.getIdentifyCount(), 2);
+
+        // verify existing database still intact
+        assertTrue(oldDbFile.exists());
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        assertEquals(oldDbHelper.getLongValue("sequence_number").longValue(), 1000L);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        // verify modifying new database does not affect old database
+        newDbHelper.insertOrReplaceKeyValue("device_id", "fakeDeviceId");
+        assertEquals(newDbHelper.getValue("device_id"), "fakeDeviceId");
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        newDbHelper.addIdentify("testIdentify3");
+        assertEquals(newDbHelper.getIdentifyCount(), 3);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+    }
+
+    @Test
+    public void testDoNotMigrateExistingDatabaseFile() {
+        String deviceId = "testDeviceId";
+        String event1 = "testEvent1";
+        String identify1 = "testIdentify1";
+        String identify2 = "testIdentify2";
+
+        String newApiKey = "1234567890";
+        String newApiKeySuffix = newApiKey.substring(0, 6);
+
+        // Setup existing Databasefile
+        DatabaseHelper oldDbHelper = DatabaseHelper.getDatabaseHelper(context);
+        oldDbHelper.insertOrReplaceKeyValue("device_id", deviceId);
+        oldDbHelper.insertOrReplaceKeyLongValue("sequence_number", 1000L);
+        oldDbHelper.addEvent(event1);
+        oldDbHelper.addIdentify(identify1);
+        oldDbHelper.addIdentify(identify2);
+
+        File oldDbFile = context.getDatabasePath(Constants.DATABASE_NAME);
+        assertTrue(oldDbFile.exists());
+        File newDbFile = context.getDatabasePath(Constants.DATABASE_NAME + "_" + newApiKeySuffix);
+        assertFalse(newDbFile.exists());
+
+        // Migrate with init - set newBlankInstance to true to skip db file migration
+        Amplitude.getInstance("new app").initialize(context, newApiKey, null, true);
+
+        // database file will be created once app goes through deviceId init process
+        assertFalse(newDbFile.exists());
+        Shadows.shadowOf(Amplitude.getInstance("new app").logThread.getLooper()).runToEndOfTasks();
+        assertTrue(newDbFile.exists());
+        DatabaseHelper newDbHelper = DatabaseHelper.getDatabaseHelper(context, newApiKeySuffix);
+        assertFalse(newDbHelper.getValue("device_id").equals(deviceId));
+        assertEquals(newDbHelper.getEventCount(), 0);
+        assertEquals(newDbHelper.getIdentifyCount(), 0);
+
+        // verify existing database still intact
+        assertTrue(oldDbFile.exists());
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        assertEquals(oldDbHelper.getLongValue("sequence_number").longValue(), 1000L);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        // verify modifying new database does not affect old database
+        newDbHelper.insertOrReplaceKeyValue("device_id", "fakeDeviceId");
+        assertEquals(newDbHelper.getValue("device_id"), "fakeDeviceId");
+        assertEquals(oldDbHelper.getValue("device_id"), deviceId);
+        newDbHelper.addIdentify("testIdentify3");
+        assertEquals(newDbHelper.getIdentifyCount(), 1);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
     }
 }

--- a/test/com/amplitude/api/UpgradePrefsTest.java
+++ b/test/com/amplitude/api/UpgradePrefsTest.java
@@ -1,9 +1,7 @@
 package com.amplitude.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import org.junit.After;
 import org.junit.Before;
@@ -13,8 +11,10 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
-import android.content.Context;
-import android.content.SharedPreferences;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -106,11 +106,9 @@ public class UpgradePrefsTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_DEVICE_ID, deviceId).commit();
 
-        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context));
-        assertEquals(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY),
-            deviceId
-        );
+        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context, null, apiKeySuffix));
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
+        assertEquals(dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY), deviceId);
 
         // deviceId should be removed from sharedPrefs after upgrade
         assertNull(prefs.getString(Constants.PREFKEY_DEVICE_ID, null));
@@ -118,10 +116,9 @@ public class UpgradePrefsTest extends BaseTest {
 
     @Test
     public void testUpgradeDeviceIdToDBEmpty() {
-        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context));
-        assertNull(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
-        );
+        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context, null, apiKeySuffix));
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
+        assertNull(dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY));
     }
 
     @Test
@@ -134,14 +131,12 @@ public class UpgradePrefsTest extends BaseTest {
                 .commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context));
+        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context, null, apiKeySuffix));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
-        assertEquals(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY),
-            deviceId
-        );
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
+        assertEquals(dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY), deviceId);
 
         // deviceId should be removed from sharedPrefs after upgrade
         assertNull(target.getString(Constants.PREFKEY_DEVICE_ID, null));
@@ -156,13 +151,12 @@ public class UpgradePrefsTest extends BaseTest {
                 .commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context));
+        assertTrue(AmplitudeClient.upgradeDeviceIdToDB(context, null, apiKeySuffix));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
         assertNull(target.getString(Constants.PREFKEY_DEVICE_ID, null));
-        assertNull(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
-        );
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKeySuffix);
+        assertNull(dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY));
     }
 }


### PR DESCRIPTION
Allowing multiple apps on Android SDK is way more straightforward than on JS SDK. 

Android SDK is already setup with Amplitude / AmplitudeClient classes, with Amplitude.getInstance() a standard part of our API. Just need to update Amplitude to manage a map of different instance names to different AmplitudeClient instances. Like with JS SDK, if the instance name is blank or null, then we default to a "$defaultInstance" name.

All events and a few meta data + settings are stored in a Sqlite db file. To separate these out for each instance, we give each instance its own Sqlite db file, and the name of the db file is appended with that instance's apiKey for uniqueness. This does mean that the AmplitudeClient instance needs to be initialized with the apiKey before being able to interact with the database. We already do an api key check in all public methods. 

DatabaseHelper has been updated to also manage separate instances for each Sqlite db file. Here we simply use the api key as the map key.

Apps upgrading from single API key to multiple API keys will probably want to keep continuity with their existing apps (keep the same deviceId/userIds for returning users). Added a migration path where we make a copy of the old db file, and copy it to a new db file with the new naming scheme. For people who want a completely new blank app (not inheriting from existing app), I added a flag during initialization to skip the migration process.

It looks like there are a lot of deletions and additions in this PR, but most of it is just migrating tests from AmplitudeTests to AmplitudeClientTests. 