### PR TITLE
Update gitignore and SDK path env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist/
 *.asc
 .idea/
 *.iml
+.classpath
+.project
+.settings/
+target/

--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
     <property name="test.reports" location="${dist}/reports"/>
 
     <property environment="env" />
-    <property name="android-sdk-path" value="${env.ANDROID_SDK}" />
+    <property name="android-sdk-path" value="${env.ANDROID_HOME}" />
     <property name="android-target" value="${env.ANDROID_TARGET}" />
 
     <property name="groupId" value="com.amplitude" />


### PR DESCRIPTION
Adds four entries to .gitignore that should not be committed to source control, but will show up in `git status` after building the project or opening it in Eclipse.
Also makes a small change to the SDK path environment variable in build.xml. The standard name is `ANDROID_HOME` - no need for a duplicate "`ANDROID_SDK`".
