### PR TITLE
Update to OKHttp v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Unreleased
 
 * Add support for logging events to multiple Amplitude apps. See [Readme](https://github.com/amplitude/Amplitude-Android#tracking-events-to-multiple-amplitude-apps) for details.
+* Update to OKHttp v3.0.1.
 
 ## 2.5.0 (January 15, 2016)
 
 * Add ability to clear all user properties.
-* Check that SDK is initialized when user calls enableForegroundTracking, identify, setUserProperties
+* Check that SDK is initialized when user calls enableForegroundTracking, identify, setUserProperties.
 
 ## 2.4.0 (December 15, 2015)
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>2.2.0</version>
+      <version>3.0.1</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>2.2.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -9,11 +9,6 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.amplitude.security.MD5;
-import com.squareup.okhttp.FormEncodingBuilder;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -28,6 +23,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class AmplitudeClient {
 
@@ -891,7 +891,7 @@ public class AmplitudeClient {
             logger.e(TAG, e.toString());
         }
 
-        RequestBody body = new FormEncodingBuilder()
+        FormBody body = new FormBody.Builder()
             .add("v", apiVersionString)
             .add("client", apiKey)
             .add("e", events)

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -3,9 +3,6 @@ package com.amplitude.api;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -22,6 +19,9 @@ import org.robolectric.shadows.ShadowLooper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -2,10 +2,6 @@ package com.amplitude.api;
 
 import android.content.Context;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -19,6 +15,10 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.fail;
@@ -78,7 +78,7 @@ public class BaseTest {
 
         if (withServer) {
             server = new MockWebServer();
-            server.play();
+            server.start();
         }
 
         if (clock == null) {
@@ -94,7 +94,7 @@ public class BaseTest {
         }
 
         if (server != null) {
-            amplitude.url = server.getUrl("/").toString();
+            amplitude.url = server.url("/").toString();
         }
     }
 

--- a/test/com/amplitude/api/InitializeTest.java
+++ b/test/com/amplitude/api/InitializeTest.java
@@ -2,14 +2,14 @@ package com.amplitude.api;
 
 import android.content.Context;
 
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/test/com/amplitude/api/PinningTest.java
+++ b/test/com/amplitude/api/PinningTest.java
@@ -1,8 +1,5 @@
 package com.amplitude.api;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +8,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)


### PR DESCRIPTION
PR in response to: https://github.com/amplitude/Amplitude-Android/issues/73

Few changes:

1. Formencodingbuilder has been replaced with Formbody.builder
2. The new OkhttpClient is stateless, no more getters and setters. To have a custom SSLSocketFactory you need to build a new OkHttpClient instance using the builder. This has to be done in the initialize method, no longer need a separate makeEventUploadPostRequest method
3. Allow multiple named instances of PinnedAmplitudeClient

Note this does increase the size of amplitude-android-with-dependencies from 411kb to 488kb

