### PR TITLE
Add Wrapper to Un-Set User Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add support for logging events to multiple Amplitude apps. See [Readme](https://github.com/amplitude/Amplitude-Android#tracking-events-to-multiple-amplitude-apps) for details.
 * Update to OKHttp v3.0.1.
+* Add wrapper methods to unset user properties from Unity.
 
 ## 2.5.0 (January 15, 2016)
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ You may use `clearUserProperties` to clear all user properties at once. Note: th
 Amplitude.getInstance().clearUserProperties();
 ```
 
+### Clearing Specific User Properties with `unsetUserProperties` ###
+
+You may use `unsetUserProperties` shorthand to unset multiple user properties at once.  This method is simply a wrapper around `Identify.unset` and `identify`.
+
+```java
+String[] userProperties = {"KEY_GOES_HERE", "OTHER_KEY_GOES_HERE"};
+Amplitude.getInstance().unsetUserProperties(userProperties);
+```
+
 # Tracking Revenue #
 
 To track revenue from a user, call `logRevenue()` each time a user generates revenue. For example:

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -670,6 +670,24 @@ public class AmplitudeClient {
         });
     }
 
+    public void unsetUserProperties(final String[] userProperties) {
+        if (userProperties == null || userProperties.length == 0 ||
+                !contextAndApiKeySet("unsetUserProperties")) {
+            return;
+        }
+
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                Identify identify = new Identify();
+                for (int i = 0; i < userProperties.length; i++) {
+                    identify.unset(userProperties[i]);
+                }
+                identify(identify);
+            }
+        });
+    }
+
     public void clearUserProperties() {
         Identify identify = new Identify().clearAll();
         identify(identify);

--- a/src/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -73,6 +73,10 @@ public class AmplitudePlugin {
         Amplitude.getInstance().setUserProperties(properties);
     }
 
+    public static void unsetUserProperties(String propertiesList) {
+        Amplitude.getInstance().unsetUserProperties(propertiesList.split(","));
+    }
+
     public static void logRevenue(double amount) {
         Amplitude.getInstance().logRevenue(amount);
     }

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -17,6 +17,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -195,6 +196,47 @@ public class AmplitudeClientTest extends BaseTest {
 
         JSONObject setOperations = userPropertiesOperations.optJSONObject(Constants.AMP_OP_SET);
         assertTrue(compareJSONObjects(userProperties, setOperations));
+    }
+
+    @Test
+    public void testUnsetUserProperties() {
+        ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
+
+        // setting null or empty user properties does nothing
+        amplitude.unsetUserProperties(null);
+        looper.runToEndOfTasks();
+        assertEquals(getUnsentEventCount(), 0);
+        assertEquals(getUnsentIdentifyCount(), 0);
+        amplitude.unsetUserProperties(new String[0]);
+        looper.runToEndOfTasks();
+        assertEquals(getUnsentEventCount(), 0);
+        assertEquals(getUnsentIdentifyCount(), 0);
+
+        String[] userProperties = new String[] { "key1", "key2" };
+        amplitude.unsetUserProperties(userProperties);
+        looper.runToEndOfTasks();
+        assertEquals(getUnsentEventCount(), 0);
+        assertEquals(getUnsentIdentifyCount(), 1);
+        JSONObject event = getLastUnsentIdentify();
+        assertEquals(Constants.IDENTIFY_EVENT, event.optString("event_type"));
+        assertEquals(event.optJSONObject("event_properties").length(), 0);
+
+        JSONObject userPropertiesOperations = event.optJSONObject("user_properties");
+        assertEquals(userPropertiesOperations.length(), 1);
+        assertTrue(userPropertiesOperations.has(Constants.AMP_OP_UNSET));
+
+        JSONObject unsetOperations = userPropertiesOperations.optJSONObject(Constants.AMP_OP_UNSET);
+        boolean matches = true;
+        Iterator<?> keys = unsetOperations.keys();
+        int i = 0;
+        while (keys.hasNext() && i < userProperties.length) {
+            if (!keys.next().equals(userProperties[i])) {
+                matches = false;
+                break;
+            }
+            ++i;
+        }
+        assertTrue(matches);
     }
 
     @Test


### PR DESCRIPTION
Adds ``unsetUserProperties`` to AmplitudeClient and AmplitudePlugin.  This is meant to make it much easier for Unity to access this functionality.