### PR TITLE
V2.5.1 patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix bug where updateServer sets the wrong batchLimit when limit is false.
+
 ## 2.5.0 (January 15, 2016)
 
 * Add ability to clear all user properties.

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -795,6 +795,7 @@ public class AmplitudeClient {
             return;
         }
 
+        // if returning out of this block, always be sure to set uploadingCurrently to false!!
         if (!uploadingCurrently.getAndSet(true)) {
             DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
             long totalEventCount = dbHelper.getTotalEventCount();

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -211,17 +211,17 @@ class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     synchronized List<JSONObject> getEvents(
-                                        long upToId, int limit) throws JSONException {
+                                        long upToId, long limit) throws JSONException {
         return getEventsFromTable(EVENT_TABLE_NAME, upToId, limit);
     }
 
     synchronized List<JSONObject> getIdentifys(
-                                        long upToId, int limit) throws JSONException {
+                                        long upToId, long limit) throws JSONException {
         return getEventsFromTable(IDENTIFY_TABLE_NAME, upToId, limit);
     }
 
     synchronized List<JSONObject> getEventsFromTable(
-                                    String table, long upToId, int limit) throws JSONException {
+                                    String table, long upToId, long limit) throws JSONException {
         List<JSONObject> events = new LinkedList<JSONObject>();
         Cursor cursor = null;
         try {


### PR DESCRIPTION
Issue: infinite threading loop in the case where a successful event upload triggers another event upload of the remaining events. The second call to updateServer will have limit set to false, which sets the batchLimit to -1. This is so that the dbHelper knows to fetch all remaining events and identifies; however, this breaks the mergeEvent logic, resulting in 0 events passed to makeEventUploadRequest. This doesn't cause the SDK/app to run out of memory since we are always posting to the log and http threads. However, when the app is idling, these 2 threads will continue to call the functions without stop.

Changes: always have batchLimit be the default (30). The limit argument in updateServer just switches between using the default limit or using the backoffUploadLimit (for the backoff). Return out of updateServer if there are no events, instead of just always posting to the http thread. 

Added a test case for this.

Pushing this as a v2.5.1 patch for immediate release, will then merge into master 