### PR TITLE
Catch security exceptions thrown during getProviders and location lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Add documentation for SDK functions. You can take a look [here](https://rawgit.com/amplitude/Amplitude-Android/master/javadoc/index.html). A link has also been added to the Readme.
+* Fix bug where fetching the user's location on select devices throws a SecurityException, causing a crash.
 
 ## 2.7.1 (April 19, 2016)
 

--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -306,10 +306,14 @@ public class DeviceInfo {
             return null;
         }
 
-        List<String> providers = locationManager.getProviders(true);
-
         // It's possible that the location service is running out of process
         // and the remote getProviders call fails. Handle null provider lists.
+        List<String> providers = null;
+        try {
+            providers = locationManager.getProviders(true);
+        } catch (SecurityException e) {
+            // failed to get providers list
+        }
         if (providers == null) {
             return null;
         }
@@ -320,6 +324,8 @@ public class DeviceInfo {
             try {
                 location = locationManager.getLastKnownLocation(provider);
             } catch (IllegalArgumentException e) {
+                // failed to get last known location from provider
+            } catch (SecurityException e) {
                 // failed to get last known location from provider
             }
             if (location != null) {


### PR DESCRIPTION
According to https://github.com/amplitude/Amplitude-Android/issues/104, it seems that trying to fetch the location information might sometimes fail on select devices. We want to catch the exception and make sure it doesn't crash the app/SDK.

Not sure why that security exception is occurring though, fetching location information shouldn't need anything other than location permissions. It seems to be isolated to select Android devices