### PR TITLE
Add support for Amazon advertising ID

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1699,6 +1699,7 @@ public class AmplitudeClient {
         invalidDeviceIds.add("000000000000000"); // Common Serial Number
         invalidDeviceIds.add("Android");
         invalidDeviceIds.add("DEFACE");
+        invalidDeviceIds.add("00000000-0000-0000-0000-000000000000");
 
         return invalidDeviceIds;
     }

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -135,6 +135,10 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(amplitude.getDeviceId(), deviceId);
         assertEquals(dbHelper.getValue(amplitude.DEVICE_ID_KEY), deviceId);
 
+        amplitude.setDeviceId("00000000-0000-0000-0000-000000000000");
+        assertEquals(amplitude.getDeviceId(), deviceId);
+        assertEquals(dbHelper.getValue(amplitude.DEVICE_ID_KEY), deviceId);
+
         // set valid device id
         String newDeviceId = UUID.randomUUID().toString();
         amplitude.setDeviceId(newDeviceId);

--- a/test/com/amplitude/api/DeviceInfoTest.java
+++ b/test/com/amplitude/api/DeviceInfoTest.java
@@ -1,11 +1,13 @@
 package com.amplitude.api;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.location.Geocoder;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Build;
+import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
 
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
@@ -34,10 +36,7 @@ import org.robolectric.util.ReflectionHelpers;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -166,7 +165,7 @@ public class DeviceInfoTest {
     }
 
     @Test
-    public void testGetAdvertisingId() {
+    public void testGetAdvertisingIdFromGoogleDevice() {
         PowerMockito.mockStatic(AdvertisingIdClient.class);
         String advertisingId = "advertisingId";
         AdvertisingIdClient.Info info = new AdvertisingIdClient.Info(
@@ -184,6 +183,23 @@ public class DeviceInfoTest {
         // still get advertisingId even if limit ad tracking disabled
         assertEquals(advertisingId, deviceInfo.getAdvertisingId());
         assertFalse(deviceInfo.isLimitAdTrackingEnabled());
+    }
+
+    @Test
+    public void testGetAdvertisingIdFromAmazonDevice() {
+        ReflectionHelpers.setStaticField(Build.class, "MANUFACTURER", "Amazon");
+
+        String advertisingId = "advertisingId";
+        ContentResolver cr = context.getContentResolver();
+
+        Secure.putInt(cr, "limit_ad_tracking", 1);
+        Secure.putString(cr, "advertising_id", advertisingId);
+
+        DeviceInfo deviceInfo = new DeviceInfo(context);
+
+        // still get advertisingID even if limit ad tracking enabled
+        assertEquals(advertisingId, deviceInfo.getAdvertisingId());
+        assertTrue(deviceInfo.isLimitAdTrackingEnabled());
     }
 
     @Test


### PR DESCRIPTION
Getting the advertiser ID currently only supports devices with Google play services. This adds support for getting the advertising ID from an Amazon device.

[Amazon advertising ID docs](https://developer.amazon.com/public/solutions/devices/fire-tablets/app-development/using-the-advertising-id-in-your-app)