### PR TITLE
setOptOut on background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix bug where `setOptOut` was not being run on background thread.
+
 ## 2.9.0 (July 07, 2016)
 
 * Add automatic flushing of unsent events on app close/minimize (through the Activity Lifecycle `onPause` callback). This only works if you call `Amplitude.getInstance().enableForegroundTracking(getApplication());`, which is recommended in the README by default for Setup. To disable you can call `Amplitude.getInstance().setFlushEventsOnClose(false);`

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -423,13 +423,19 @@ public class AmplitudeClient {
      * @param optOut whether or not to opt the user out of tracking
      * @return the AmplitudeClient
      */
-    public AmplitudeClient setOptOut(boolean optOut) {
+    public AmplitudeClient setOptOut(final boolean optOut) {
         if (!contextAndApiKeySet("setOptOut()")) {
             return this;
         }
 
-        this.optOut = optOut;
-        dbHelper.insertOrReplaceKeyLongValue(OPT_OUT_KEY, optOut ? 1L : 0L);
+        final AmplitudeClient client = this;
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                client.optOut = optOut;
+                dbHelper.insertOrReplaceKeyLongValue(OPT_OUT_KEY, optOut ? 1L : 0L);
+            }
+        });
         return this;
     }
 

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -292,6 +292,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 0L);
 
         amplitude.setOptOut(true);
+        looper.runToEndOfTasks();
         assertTrue(amplitude.isOptedOut());
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 1L);
         RecordedRequest request = sendEvent(amplitude, "test_opt_out", null);
@@ -299,6 +300,7 @@ public class AmplitudeClientTest extends BaseTest {
 
         // Event shouldn't be sent event once opt out is turned off.
         amplitude.setOptOut(false);
+        looper.runToEndOfTasks();
         assertFalse(amplitude.isOptedOut());
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 0L);
         looper.runToEndOfTasks();

--- a/test/com/amplitude/api/InitializeTest.java
+++ b/test/com/amplitude/api/InitializeTest.java
@@ -111,6 +111,8 @@ public class InitializeTest extends BaseTest {
 
     @Test
     public void testInitializeOptOut() {
+        ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
+
         String sourceName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
@@ -119,12 +121,13 @@ public class InitializeTest extends BaseTest {
         assertNull(dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY));
 
         amplitude.initialize(context, apiKey);
-        Shadows.shadowOf(amplitude.logThread.getLooper()).runOneTask();
+        looper.runOneTask();
 
         assertTrue(amplitude.isOptedOut());
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 1L);
 
         amplitude.setOptOut(false);
+        looper.runOneTask();
         assertFalse(amplitude.isOptedOut());
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 0L);
 


### PR DESCRIPTION
Addresses https://github.com/amplitude/Amplitude-Android/issues/113
With this [change](https://github.com/amplitude/Amplitude-Android/pull/109/files) that went out in v2.8.0, I forgot to also update `setOptOut` to run on background thread.