### PR TITLE
set location listening on background thread

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -317,11 +317,16 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient enableLocationListening() {
-        if (deviceInfo == null) {
-            throw new IllegalStateException(
-                    "Must initialize before acting on location listening.");
-        }
-        deviceInfo.setLocationListening(true);
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                if (deviceInfo == null) {
+		    throw new IllegalStateException(
+		            "Must initialize before acting on location listening.");
+                }
+                deviceInfo.setLocationListening(true);
+            }
+        });
         return this;
     }
 
@@ -332,11 +337,16 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient disableLocationListening() {
-        if (deviceInfo == null) {
-            throw new IllegalStateException(
-                    "Must initialize before acting on location listening.");
-        }
-        deviceInfo.setLocationListening(false);
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                if (deviceInfo == null) {
+		    throw new IllegalStateException(
+		            "Must initialize before acting on location listening.");
+                }
+                deviceInfo.setLocationListening(false);
+            }
+        });
         return this;
     }
 


### PR DESCRIPTION
Otherwise, can't set location listening reliably -- likely to throw exception (see below), since init is on background thread, and no way to get callback when init completed, in order to enable/disable location listening.

```
java.lang.IllegalStateException: Must initialize before acting on location listening.
at com.amplitude.api.AmplitudeClient.disableLocationListening(AmplitudeClient.java:336)
```