### PR TITLE
Handle illegal arguement exception for bad lat lon values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Handle IllegalArgumentException thrown by Android Geocoder for bad lat / lon values.
+
 ## 2.9.2 (July 14, 2016)
 
 * Fix bug where `enableLocationListening` and `disableLocationListening` were not being run on background thread. Thanks to @elevenfive for PR.

--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -150,6 +150,8 @@ public class DeviceInfo {
                     // Failed to reverse geocode location
                 } catch (NoSuchMethodError e) {
                     // failed to fetch geocoder
+                } catch (IllegalArgumentException e) {
+                    // Bad lat / lon values can cause Geocoder to throw IllegalArgumentExceptions
                 }
             }
             return null;


### PR DESCRIPTION
Sometimes the Android device GPS can rarely give bad values for Lat / Lon: https://github.com/amplitude/Amplitude-Android/issues/119 (for example 1.02E7 when Lat values need to be between -90 and 90). The Android geocoder will throw IllegalArgumentExceptions in those cases. We just need to catch those exceptions.