### PR TITLE
Gracefully catch and handle CursorWindowAllocationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Catch and handle `CursorWindowAllocationException` thrown when the SDK is querying from the Sqlite DB when app memory is low. If the exception is caught during `initialize`, then it is treated as if `initialize` was never called. If the exception is caught during the uploading of unsent events, then the upload is deferred to a later time.
+
 ## 2.9.2 (July 14, 2016)
 
 * Fix bug where `enableLocationListening` and `disableLocationListening` were not being run on background thread. Thanks to @elevenfive for PR.

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -13,7 +13,6 @@ import com.amplitude.security.MD5;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.w3c.dom.Text;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -452,6 +451,10 @@ public class AmplitudeClient {
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
                 client.optOut = optOut;
                 dbHelper.insertOrReplaceKeyLongValue(OPT_OUT_KEY, optOut ? 1L : 0L);
             }
@@ -697,8 +700,8 @@ public class AmplitudeClient {
      * @see <a href="https://github.com/amplitude/Amplitude-Android#setting-groups">
      *     Setting Groups</a>
      */
-    public void logEventSync(String eventType, JSONObject eventProperties, JSONObject group) {
-        logEventSync(eventType, eventProperties, group, false);
+    public void logEventSync(String eventType, JSONObject eventProperties, JSONObject groups) {
+        logEventSync(eventType, eventProperties, groups, false);
     }
 
     /**
@@ -777,9 +780,14 @@ public class AmplitudeClient {
         final JSONObject copyEventProperties = eventProperties;
         final JSONObject copyUserProperties = userProperties;
         final JSONObject copyGroups = groups;
+        final AmplitudeClient client = this;
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
                 logEvent(
                     eventType, copyEventProperties, apiProperties,
                     copyUserProperties, copyGroups, timestamp, outOfSession
@@ -1255,9 +1263,15 @@ public class AmplitudeClient {
             return;
         }
 
+        final AmplitudeClient client = this;
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
+
                 // Create deep copy to try and prevent ConcurrentModificationException
                 JSONObject copy;
                 try {
@@ -1434,6 +1448,10 @@ public class AmplitudeClient {
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
                 client.userId = userId;
                 dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
             }
@@ -1460,6 +1478,10 @@ public class AmplitudeClient {
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
                 client.deviceId = deviceId;
                 dbHelper.insertOrReplaceKeyValue(DEVICE_ID_KEY, deviceId);
             }
@@ -1475,9 +1497,14 @@ public class AmplitudeClient {
             return;
         }
 
+        final AmplitudeClient client = this;
         logThread.post(new Runnable() {
             @Override
             public void run() {
+                // one more apiKey check, in case initialization failed
+                if (TextUtils.isEmpty(client.apiKey)) {
+                    return;
+                }
                 updateServer();
             }
         });

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -739,7 +739,7 @@ public class AmplitudeClient {
     public void logEventSync(String eventType, JSONObject eventProperties, JSONObject groups, boolean outOfSession) {
         if (validateLogEvent(eventType)) {
             logEvent(
-                    eventType, eventProperties, null, null, groups, getCurrentTimeMillis(), outOfSession
+                eventType, eventProperties, null, null, groups, getCurrentTimeMillis(), outOfSession
             );
         }
     }

--- a/src/com/amplitude/api/CursorWindowAllocationException.java
+++ b/src/com/amplitude/api/CursorWindowAllocationException.java
@@ -1,0 +1,14 @@
+package com.amplitude.api;
+
+/**
+ * This is Amplitude's substitute for android.database.CursorWindowAllocationException.
+ * Android's CursorWindow will throw that exception, but Android does not allow you to import
+ * the exception class directly to catch it. This is Amplitude's stand-in for that class.
+ *
+ * @hide
+ */
+public class CursorWindowAllocationException extends RuntimeException {
+    public CursorWindowAllocationException(String description) {
+        super(description);
+    }
+}

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -56,7 +56,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         return instance;
     }
 
-    private DatabaseHelper(Context context) {
+    protected DatabaseHelper(Context context) {
         super(context, Constants.DATABASE_NAME, null, Constants.DATABASE_VERSION);
         file = context.getDatabasePath(Constants.DATABASE_NAME);
     }
@@ -200,7 +200,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         return (Long) getValueFromTable(LONG_STORE_TABLE_NAME, key);
     }
 
-    private synchronized Object getValueFromTable(String table, String key) {
+    protected synchronized Object getValueFromTable(String table, String key) {
         Object value = null;
         Cursor cursor = null;
         try {
@@ -236,7 +236,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
         return getEventsFromTable(IDENTIFY_TABLE_NAME, upToId, limit);
     }
 
-    private synchronized List<JSONObject> getEventsFromTable(
+    protected synchronized List<JSONObject> getEventsFromTable(
                                     String table, long upToId, long limit) throws JSONException {
         List<JSONObject> events = new LinkedList<JSONObject>();
         Cursor cursor = null;

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -8,6 +8,7 @@ import android.database.sqlite.SQLiteDoneException;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteStatement;
+import android.text.TextUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -205,18 +206,17 @@ class DatabaseHelper extends SQLiteOpenHelper {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = getReadableDatabase();
-            cursor = db.query(
-                    table,
-                    new String[]{KEY_FIELD, VALUE_FIELD},
-                    KEY_FIELD + " = ?",
-                    new String[]{key},
-                    null, null, null, null
+            cursor = queryDb(
+                db, table, new String[]{KEY_FIELD, VALUE_FIELD}, KEY_FIELD + " = ?",
+                new String[]{key}, null, null, null, null
             );
             if (cursor.moveToFirst()) {
                 value = table.equals(STORE_TABLE_NAME) ? cursor.getString(1) : cursor.getLong(1);
             }
         } catch (SQLiteException e) {
             logger.e(TAG, "getValue failed", e);
+        } catch (RuntimeException e) {
+            convertIfCursorWindowException(e);
         } finally {
             if (cursor != null) {
                 cursor.close();
@@ -242,9 +242,11 @@ class DatabaseHelper extends SQLiteOpenHelper {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = getReadableDatabase();
-            cursor = db.query(table, new String[] { ID_FIELD, EVENT_FIELD },
-                    upToId >= 0 ? ID_FIELD + " <= " + upToId : null, null, null, null,
-                    ID_FIELD + " ASC", limit >= 0 ? "" + limit : null);
+            cursor = queryDb(
+                db, table, new String[] { ID_FIELD, EVENT_FIELD },
+                upToId >= 0 ? ID_FIELD + " <= " + upToId : null, null, null, null,
+                ID_FIELD + " ASC", limit >= 0 ? "" + limit : null
+            );
 
             while (cursor.moveToNext()) {
                 long eventId = cursor.getLong(0);
@@ -256,6 +258,8 @@ class DatabaseHelper extends SQLiteOpenHelper {
             }
         } catch (SQLiteException e) {
             logger.e(TAG, String.format("getEvents from %s failed", table), e);
+        } catch (RuntimeException e) {
+            convertIfCursorWindowException(e);
         } finally {
             if (cursor != null) {
                 cursor.close();
@@ -378,5 +382,27 @@ class DatabaseHelper extends SQLiteOpenHelper {
 
     boolean dbFileExists() {
         return file.exists();
+    }
+
+    // add level of indirection to facilitate mocking during unit tests
+    Cursor queryDb(
+        SQLiteDatabase db, String table, String[] columns, String selection,
+        String[] selectionArgs, String groupBy, String having, String orderBy, String limit
+    ) {
+        return db.query(table, columns, selection, selectionArgs, groupBy, having, orderBy, limit);
+    }
+
+    /*
+        Checks if the RuntimeException is an android.database.CursorWindowAllocationException.
+        If it is, then wrap the message in Amplitude's CursorWindowAllocationException so the
+        AmplitudeClient can handle it. If not then rethrow.
+     */
+    private static void convertIfCursorWindowException(RuntimeException e) {
+        String message = e.getMessage();
+        if (!TextUtils.isEmpty(message) && message.startsWith("Cursor window allocation of")) {
+            throw new CursorWindowAllocationException(message);
+        } else {
+            throw e;
+        }
     }
 }

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -2,6 +2,8 @@ package com.amplitude.api;
 
 import android.content.Context;
 
+
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -48,6 +50,26 @@ public class BaseTest {
 
         @Override
         protected long getCurrentTimeMillis() { return mockClock.currentTimeMillis(); }
+    }
+
+    // override AmplitudeDatabaseHelper to throw Cursor Allocation Exception
+    protected class MockDatabaseHelper extends DatabaseHelper {
+        protected MockDatabaseHelper(Context context) {
+            super(context);
+        }
+
+        @Override
+        protected synchronized Object getValueFromTable(String table, String key) {
+            // cannot import CursorWindowAllocationException, so we throw the base class instead
+            throw new RuntimeException("Cursor window allocation of 2048 kb failed.");
+        }
+
+        @Override
+        protected synchronized List<JSONObject> getEventsFromTable(
+                String table, long upToId, long limit) throws JSONException {
+            // cannot import CursorWindowAllocationException, so we throw the base class instead
+            throw new RuntimeException("Cursor window allocation of 2048 kb failed.");
+        }
     }
 
     protected AmplitudeClient amplitude;

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -1,6 +1,8 @@
 package com.amplitude.api;
 
 import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -52,19 +54,16 @@ public class BaseTest {
 
     // override AmplitudeDatabaseHelper to throw Cursor Allocation Exception
     protected class MockDatabaseHelper extends DatabaseHelper {
+
         protected MockDatabaseHelper(Context context) {
             super(context);
         }
 
         @Override
-        protected synchronized Object getValueFromTable(String table, String key) {
-            // cannot import CursorWindowAllocationException, so we throw the base class instead
-            throw new RuntimeException("Cursor window allocation of 2048 kb failed.");
-        }
-
-        @Override
-        protected synchronized List<JSONObject> getEventsFromTable(
-                String table, long upToId, long limit) throws JSONException {
+        Cursor queryDb(
+            SQLiteDatabase db, String table, String[] columns, String selection,
+            String[] selectionArgs, String groupBy, String having, String orderBy, String limit
+        ) {
             // cannot import CursorWindowAllocationException, so we throw the base class instead
             throw new RuntimeException("Cursor window allocation of 2048 kb failed.");
         }

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -2,8 +2,6 @@ package com.amplitude.api;
 
 import android.content.Context;
 
-
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/test/com/amplitude/api/DatabaseHelperTest.java
+++ b/test/com/amplitude/api/DatabaseHelperTest.java
@@ -73,7 +73,8 @@ public class DatabaseHelperTest extends BaseTest {
     @Test
     public void testCreate() {
         dbInstance.onCreate(dbInstance.getWritableDatabase());
-        assertEquals(1, insertOrReplaceKeyValue("test_key", "test_value"));
+        // AmplitudeClient.initialize will deviceId to DB, so there's already 1 entry in str table
+        assertEquals(2, insertOrReplaceKeyValue("test_key", "test_value"));
         // due to upgradeSharedPrefsToDb, there are already 5 entries in long table
         // so this next insertion will be row 6
         assertEquals(6, insertOrReplaceKeyLongValue("test_key", 1L));

--- a/test/com/amplitude/api/InitializeTest.java
+++ b/test/com/amplitude/api/InitializeTest.java
@@ -166,7 +166,7 @@ public class InitializeTest extends BaseTest {
         amplitude.initialize(context, apiKey);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runOneTask();
 
-        assertEquals(amplitude.getLastEventId(), 3L);
+        assertEquals(amplitude.lastEventId, 3L);
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.LAST_EVENT_ID_KEY), 3L);
 
         amplitude.logEvent("testEvent");
@@ -178,7 +178,7 @@ public class InitializeTest extends BaseTest {
 
         assertEquals(events.getJSONObject(0).getLong("event_id"), 1L);
 
-        assertEquals(amplitude.getLastEventId(), 1L);
+        assertEquals(amplitude.lastEventId, 1L);
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.LAST_EVENT_ID_KEY), 1L);
 
         // verify shared prefs deleted
@@ -215,7 +215,7 @@ public class InitializeTest extends BaseTest {
         amplitude.initialize(context, apiKey);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runOneTask();
 
-        assertEquals(amplitude.getLastEventTime(), 5000L);
+        assertEquals(amplitude.lastEventTime, 5000L);
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.LAST_EVENT_TIME_KEY), 5000L);
 
         // verify shared prefs deleted
@@ -261,8 +261,8 @@ public class InitializeTest extends BaseTest {
 
         // after upgrade, pref values still there since they weren't deleted
         assertEquals(amplitude.deviceId, "testDeviceId");
-        assertEquals(amplitude.getPreviousSessionId(), 1000L);
-        assertEquals(amplitude.getLastEventTime(), 2000L);
+        assertEquals(amplitude.previousSessionId, 1000L);
+        assertEquals(amplitude.lastEventTime, 2000L);
         assertNull(amplitude.userId);
     }
 
@@ -292,20 +292,20 @@ public class InitializeTest extends BaseTest {
         looper.runToEndOfTasks();
 
         assertEquals(amplitude.deviceId, "testDeviceId");
-        assertEquals(amplitude.getPreviousSessionId(), 6000L);
-        assertEquals(amplitude.getLastEventTime(), 7000L);
+        assertEquals(amplitude.previousSessionId, 6000L);
+        assertEquals(amplitude.lastEventTime, 7000L);
         assertNull(amplitude.userId);
 
         // log first event
         amplitude.logEvent("testEvent1");
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), 6000L);
-        assertEquals(amplitude.getLastEventTime(), 8000L);
+        assertEquals(amplitude.previousSessionId, 6000L);
+        assertEquals(amplitude.lastEventTime, 8000L);
 
         // log second event
         amplitude.logEvent("testEvent2");
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), 14000L);
-        assertEquals(amplitude.getLastEventTime(), 14000L);
+        assertEquals(amplitude.previousSessionId, 14000L);
+        assertEquals(amplitude.lastEventTime, 14000L);
     }
 }

--- a/test/com/amplitude/api/SessionTest.java
+++ b/test/com/amplitude/api/SessionTest.java
@@ -926,7 +926,6 @@ public class SessionTest extends BaseTest {
         // log an event, should not be uploaded
         amplitude.logEventAsync("testEvent", null, null, null, null, timestamps[0], false);
         looper.runOneTask();
-        looper.runOneTask();
         assertEquals(getUnsentEventCount(), 1);
 
         // force client into background and verify no flushing of events

--- a/test/com/amplitude/api/SessionTest.java
+++ b/test/com/amplitude/api/SessionTest.java
@@ -424,17 +424,17 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertFalse(amplitude.isInForeground());
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertTrue(amplitude.isInForeground());
-        assertEquals(amplitude.getPreviousSessionId(), timestamp);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamp);
+        assertEquals(amplitude.previousSessionId, timestamp);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamp);
     }
 
     @Test
@@ -444,18 +444,18 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertFalse(amplitude.isInForeground());
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         assertTrue(amplitude.isInForeground());
-        assertEquals(amplitude.getPreviousSessionId(), timestamp);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamp);
+        assertEquals(amplitude.previousSessionId, timestamp);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamp);
 
         // verify that start session event sent
         assertEquals(getUnsentEventCount(), 1);
@@ -482,21 +482,21 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp, timestamp + minTimeBetweenSessionsMillis};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
 
         callBacks.onActivityPaused(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertFalse(amplitude.isInForeground());
     }
 
@@ -510,24 +510,24 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp, timestamp + minTimeBetweenSessionsMillis};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 1);
 
         // only refresh time, no session checking
         callBacks.onActivityPaused(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertEquals(getUnsentEventCount(), 1);
     }
 
@@ -543,34 +543,34 @@ public class SessionTest extends BaseTest {
         };
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 0);
         assertTrue(amplitude.isInForeground());
 
         // only refresh time, no session checking
         callBacks.onActivityPaused(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertEquals(getUnsentEventCount(), 0);
         assertFalse(amplitude.isInForeground());
 
         // resume after min session expired window, verify new session started
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[2]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[2]);
+        assertEquals(amplitude.previousSessionId, timestamps[2]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[2]);
         assertEquals(getUnsentEventCount(), 0);
         assertTrue(amplitude.isInForeground());
     }
@@ -589,34 +589,34 @@ public class SessionTest extends BaseTest {
         };
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 1);
         assertTrue(amplitude.isInForeground());
 
         // only refresh time, no session checking
         callBacks.onActivityPaused(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertEquals(getUnsentEventCount(), 1);
         assertFalse(amplitude.isInForeground());
 
         // resume after min session expired window, verify new session started
         callBacks.onActivityResumed(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[2]);
-        assertEquals(amplitude.getLastEventId(), 3);
-        assertEquals(amplitude.getLastEventTime(), timestamps[2]);
+        assertEquals(amplitude.previousSessionId, timestamps[2]);
+        assertEquals(amplitude.lastEventId, 3);
+        assertEquals(amplitude.lastEventTime, timestamps[2]);
         assertEquals(getUnsentEventCount(), 3);
         assertTrue(amplitude.isInForeground());
 
@@ -662,28 +662,28 @@ public class SessionTest extends BaseTest {
         };
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
 
         callBacks.onActivityPaused(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertFalse(amplitude.isInForeground());
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[2]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, timestamps[2]);
         assertTrue(amplitude.isInForeground());
     }
 
@@ -701,31 +701,31 @@ public class SessionTest extends BaseTest {
         };
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
 
         callBacks.onActivityResumed(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 1);
 
         callBacks.onActivityPaused(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[1]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[1]);
         assertFalse(amplitude.isInForeground());
         assertEquals(getUnsentEventCount(), 1);
 
         callBacks.onActivityResumed(null);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[2]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[2]);
         assertTrue(amplitude.isInForeground());
         assertEquals(getUnsentEventCount(), 1);
 
@@ -748,25 +748,25 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp + minTimeBetweenSessionsMillis - 1};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
         assertFalse(amplitude.isInForeground());
 
         // logging an event before onResume will force a session check
         amplitude.logEventAsync("test", null, null, null, null, timestamp, false);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamp);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamp);
+        assertEquals(amplitude.previousSessionId, timestamp);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamp);
         assertEquals(getUnsentEventCount(), 1);
 
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamp);
-        assertEquals(amplitude.getLastEventId(), 1);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamp);
+        assertEquals(amplitude.lastEventId, 1);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 1);
         assertTrue(amplitude.isInForeground());
 
@@ -786,26 +786,26 @@ public class SessionTest extends BaseTest {
         long [] timestamps = {timestamp + minTimeBetweenSessionsMillis};
         AmplitudeCallbacks callBacks = new AmplitudeCallbacksWithTime(amplitude, timestamps);
 
-        assertEquals(amplitude.getPreviousSessionId(), -1);
-        assertEquals(amplitude.getLastEventId(), -1);
-        assertEquals(amplitude.getLastEventTime(), -1);
+        assertEquals(amplitude.previousSessionId, -1);
+        assertEquals(amplitude.lastEventId, -1);
+        assertEquals(amplitude.lastEventTime, -1);
         assertEquals(getUnsentEventCount(), 0);
         assertFalse(amplitude.isInForeground());
 
         // logging an event before onResume will force a session check
         amplitude.logEventAsync("test", null, null, null, null, timestamp, false);
         looper.runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamp);
-        assertEquals(amplitude.getLastEventId(), 2);
-        assertEquals(amplitude.getLastEventTime(), timestamp);
+        assertEquals(amplitude.previousSessionId, timestamp);
+        assertEquals(amplitude.lastEventId, 2);
+        assertEquals(amplitude.lastEventTime, timestamp);
         assertEquals(getUnsentEventCount(), 2);
 
         // onResume after session expires will start new session
         callBacks.onActivityResumed(null);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
-        assertEquals(amplitude.getPreviousSessionId(), timestamps[0]);
-        assertEquals(amplitude.getLastEventId(), 4);
-        assertEquals(amplitude.getLastEventTime(), timestamps[0]);
+        assertEquals(amplitude.previousSessionId, timestamps[0]);
+        assertEquals(amplitude.lastEventId, 4);
+        assertEquals(amplitude.lastEventTime, timestamps[0]);
         assertEquals(getUnsentEventCount(), 4);
         assertTrue(amplitude.isInForeground());
 


### PR DESCRIPTION
This addresses: https://github.com/amplitude/Amplitude-Android/issues/42. We believe that our SDK correctly closes cursors, which would mean that these CursorWindowAllocationExceptions are caused by the app running out of memory, not something in our SDK's control. That being said, the crash still originates from our SDK, and so we should attempt to catch it and gracefully handle it, instead of crashing the app.

Our SDK uses cursors when fetching unsent events/identifies and key/value pairs. We need to catch the exception in these 3 primary use cases:

1. Fetching unsent events/identifies for upload
    * If the fetch fails, then we can simply defer the upload, and try again later maybe when the app has more free memory
2. Fetching the userId/deviceId during initialization
    * It is crucial that our SDK loads the existing userId/deviceIds during initialization, otherwise the tracked events will go to the wrong user and affect new and active user counts. If we cannot load those ids, then we cannot log any events.
    * We can set the apiKey back to null in the catch handler, as if `initialize` was never called on the SDK. All of the core SDK methods already check that an apiKey is set, and so they will just be ignored
    * The key detail here is the initialization logic is run on the background thread, so it's possible that the apiKey is set to null after a bunch of logEvents have already been scheduled (passed the apiKey check), so then we need to add an additional apiKey check inside all of the runnables
3. Fetching event metadata during logEvent
    * Whenever the SDK logs an event, it fetches some meta data like the last sequence number, increments it, sets it on the event, and then saves the new value back to the database.
    * We don't want the meta data fetching to fail, otherwise the events could end up in a weird state. What we should do is load all of the meta data into memory during initialize, and then just increment and read the values in memory. We still need to write any value updates to the database, but those don't require a Cursor object, so those should not fail

Couple extra things to note:
* I was not able to directly import the `CursorWindowAllocationException` class. I can see it in the Android Source, but I'm not able to access it directly. So instead what I have to do is catch the base class `RuntimeException` and do a string check on the message. If the exception caught is not a CursorWindowAllocationException, we need to rethrow it
* Since the entire initialization logic was moved to a background thread, the `initializeDeviceInfo` does not need to be explicitly wrapped in the `runOnLogThread`. That wrapping also prevents unit tests from running correctly since the logThread is improperly named to "main" thread in unit testing