### PR TITLE
identify with outOfSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add ability to log identify events outOfSession, this is useful for updating user properties without triggering session-handling logic.
+
 ## 2.10.0 (October 12, 2016)
 
 * Catch and handle `CursorWindowAllocationException` thrown when the SDK is querying from the SQLite DB when app memory is low. If the exception is caught during `initialize`, then it is treated as if `initialize` was never called. If the exception is caught during the uploading of unsent events, then the upload is deferred to a later time.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Other Session Options:
     Amplitude.getInstance().logEvent("EVENT", null, true);
     ```
 
+3. You can also log Identify events as out of session by setting input parameter `outOfSession` to `true` when calling `identify()`:
+
+    ```java
+    Identify identify = new Identify().set("key", "value);
+    Amplitude.getInstance().identify(identify, true);
+    ```
+
 ### Getting the Session Id ###
 
 You can use the helper method `getSessionId` to get the value of the current sessionId:

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1297,12 +1297,27 @@ public class AmplitudeClient {
      *     User Properties</a>
      */
     public void identify(Identify identify) {
+        identify(identify, false);
+    }
+
+    /**
+     * Identify. Use this to send an {@link com.amplitude.api.Identify} object containing
+     * user property operations to Amplitude server. If outOfSession is true, then the identify
+     * event is sent with a session id of -1, and does not trigger any session-handling logic.
+     *
+     * @param identify an {@link com.amplitude.api.Identify} object
+     * @param outOfSession whther to log the identify event out of session
+     * @see com.amplitude.api.Identify
+     * @see <a href="https://github.com/amplitude/Amplitude-Android#user-properties-and-user-property-operations">
+     *     User Properties</a>
+     */
+    public void identify(Identify identify, boolean outOfSession) {
         if (identify == null || identify.userPropertiesOperations.length() == 0
-                || !contextAndApiKeySet("identify()")) {
+            || !contextAndApiKeySet("identify()")) {
             return;
         }
         logEventAsync(Constants.IDENTIFY_EVENT, null, null,
-                identify.userPropertiesOperations, null, getCurrentTimeMillis(), false);
+            identify.userPropertiesOperations, null, getCurrentTimeMillis(), outOfSession);
     }
 
     /**

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1312,12 +1312,14 @@ public class AmplitudeClient {
      *     User Properties</a>
      */
     public void identify(Identify identify, boolean outOfSession) {
-        if (identify == null || identify.userPropertiesOperations.length() == 0
-            || !contextAndApiKeySet("identify()")) {
-            return;
-        }
-        logEventAsync(Constants.IDENTIFY_EVENT, null, null,
-            identify.userPropertiesOperations, null, getCurrentTimeMillis(), outOfSession);
+        if (
+            identify == null || identify.userPropertiesOperations.length() == 0 ||
+            !contextAndApiKeySet("identify()")
+        ) return;
+        logEventAsync(
+            Constants.IDENTIFY_EVENT, null, null, identify.userPropertiesOperations,
+            null, getCurrentTimeMillis(), outOfSession
+        );
     }
 
     /**


### PR DESCRIPTION
Some customers want to log identify events while their app is in the background, without triggering start/end session events. We can expose the outOfSession boolean as an argument.