### PR TITLE
Regenerate device id should be run on bg thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix bug where `regenerateDeviceId` was not being run on background thread. DeviceInfo.generateUUID() should be a static method.
+
 ## 2.13.0 (December 05, 2016)
 
 * Add helper method to regenerate a new random deviceId. This can be used in conjunction with `setUserId(null)` to anonymize a user after they log out. Note this is not recommended unless you know what you are doing. See [Readme](https://github.com/amplitude/Amplitude-Android#logging-out-and-anonymous-users) for more information.

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1543,9 +1543,23 @@ public class AmplitudeClient {
      * @see <a href="https://github.com/amplitude/Amplitude-Android#logging-out-and-anonymous-users">
      *     Logging Out Users</a>
      */
-    public void regenerateDeviceId() {
-        String randomId = deviceInfo.generateUUID() + "R";
-        setDeviceId(randomId);
+    public AmplitudeClient regenerateDeviceId() {
+        if (!contextAndApiKeySet("regenerateDeviceId()")) {
+            return this;
+        }
+
+        final AmplitudeClient client = this;
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+                if (TextUtils.isEmpty(client.apiKey)) { // in case initialization failed
+                    return;
+                }
+                String randomId = DeviceInfo.generateUUID() + "R";
+                setDeviceId(randomId);
+            }
+        });
+        return this;
     }
 
     /**

--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -268,7 +268,7 @@ public class DeviceInfo {
         getCachedInfo();
     }
 
-    public String generateUUID() {
+    public static String generateUUID() {
         return UUID.randomUUID().toString();
     }
 


### PR DESCRIPTION
DeviceInfo.generateUUID() should also be a static method, and should not require AmplitudeClient.deviceInfo to be initialized first