### PR TITLE
Handle null event strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* Fix crash when pulling null unsent event strings during upload.
+* Fix bug where unserializable events were being saved to unsent events table.
+* Added more logging around JSON serialization errors when logging events.
+
 ## 2.13.1 (December 15, 2016)
 
 * Fix bug where `regenerateDeviceId` was not being run on background thread. DeviceInfo.generateUUID() should be a static method.

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -251,6 +251,9 @@ class DatabaseHelper extends SQLiteOpenHelper {
             while (cursor.moveToNext()) {
                 long eventId = cursor.getLong(0);
                 String event = cursor.getString(1);
+                if (TextUtils.isEmpty(event)) {
+                    continue;
+                }
 
                 JSONObject obj = new JSONObject(event);
                 obj.put("event_id", eventId);

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -1489,4 +1489,24 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(newDeviceId, dbHelper.getValue("device_id"));
         assertTrue(newDeviceId.endsWith("R"));
     }
+
+    @Test
+    public void testSendNullEvents() throws JSONException {
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
+
+        dbHelper.addEvent(null);
+        amplitude.setLastEventId(1);
+        amplitude.getNextSequenceNumber();
+        assertEquals(getUnsentEventCount(), 1);
+
+        amplitude.logEvent("test event");
+        looper.runToEndOfTasks();
+
+        amplitude.updateServer();
+        RecordedRequest request = runRequest(amplitude);
+        JSONArray events = getEventsFromRequest(request);
+        assertEquals(events.length(), 1);
+        assertEquals(events.optJSONObject(0).optString("event_type"), "test event");
+    }
 }

--- a/test/com/amplitude/api/DatabaseHelperTest.java
+++ b/test/com/amplitude/api/DatabaseHelperTest.java
@@ -484,7 +484,7 @@ public class DatabaseHelperTest extends BaseTest {
     }
 
     @Test
-    public void testNullEventSTring() throws JSONException {
+    public void testNullEventString() throws JSONException {
         dbInstance.addEvent(null);
         List<JSONObject> events = dbInstance.getEvents(-1, -1);
         assertTrue(events.isEmpty());

--- a/test/com/amplitude/api/DatabaseHelperTest.java
+++ b/test/com/amplitude/api/DatabaseHelperTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
@@ -480,6 +481,13 @@ public class DatabaseHelperTest extends BaseTest {
         dbInstance.removeEvents(4);
         assertEquals(0, dbInstance.getEventCount());
         assertEquals(1, dbInstance.getIdentifyCount());
+    }
+
+    @Test
+    public void testNullEventSTring() throws JSONException {
+        dbInstance.addEvent(null);
+        List<JSONObject> events = dbInstance.getEvents(-1, -1);
+        assertTrue(events.isEmpty());
     }
 }
 


### PR DESCRIPTION
Android SDK crashes when loading events from db table if there's a null event string.

* check event string is not null before deserializing - this should stop the crashes
* it's important to note that the metadata state is still okay (like if it logged a null event, then lastEventId will be incremented, but it can safely skip over the null event when fetching)
* if valid events are logged after the null event, they still get sent correctly
* event servers can handle payloads with empty event lists (although if there are no events to send the SDK won't even make a request out)
* Added some more logging around JSON serialization errors - I think that's how null events are getting added to the table
* Only save the event string if it serializes properly