### PR TITLE
Added support for multiple apps (separate API keys) using non-singleton approach

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -228,7 +228,7 @@ public class AmplitudeClient {
 
         this.context = context.getApplicationContext();
         this.apiKey = apiKey;
-        this.dbHelper = DatabaseHelper.getDatabaseHelper(this.context);
+        this.dbHelper = DatabaseHelper.getDatabaseHelper(this.context, apiKey);
 
         final AmplitudeClient client = this;
         runOnLogThread(new Runnable() {
@@ -238,7 +238,7 @@ public class AmplitudeClient {
                     // this try block is idempotent, so it's safe to retry initialize if failed
                     try {
                         AmplitudeClient.upgradePrefs(context);
-                        AmplitudeClient.upgradeSharedPrefsToDB(context);
+                        AmplitudeClient.upgradeSharedPrefsToDB(context, apiKey);
                         httpClient = new OkHttpClient();
                         initializeDeviceInfo();
 
@@ -2077,8 +2077,8 @@ public class AmplitudeClient {
      * Move all data from sharedPrefs to sqlite key value store to support multi-process apps.
      * sharedPrefs is known to not be process-safe.
      */
-    static boolean upgradeSharedPrefsToDB(Context context) {
-        return upgradeSharedPrefsToDB(context, null);
+    static boolean upgradeSharedPrefsToDB(Context context, String apiKey) {
+        return upgradeSharedPrefsToDB(context, apiKey, null);
     }
 
     /**
@@ -2088,13 +2088,13 @@ public class AmplitudeClient {
      * @param sourcePkgName the source pkg name
      * @return the boolean
      */
-    static boolean upgradeSharedPrefsToDB(Context context, String sourcePkgName) {
+    static boolean upgradeSharedPrefsToDB(Context context, String apiKey, String sourcePkgName) {
         if (sourcePkgName == null) {
             sourcePkgName = Constants.PACKAGE_NAME;
         }
 
         // check if upgrade needed
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         String deviceId = dbHelper.getValue(DEVICE_ID_KEY);
         Long previousSessionId = dbHelper.getLongValue(PREVIOUS_SESSION_ID_KEY);
         Long lastEventTime = dbHelper.getLongValue(LAST_EVENT_TIME_KEY);

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -14,12 +14,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 class DatabaseHelper extends SQLiteOpenHelper {
 
-    static DatabaseHelper instance;
+    static Map<String, DatabaseHelper> instances = new HashMap<>(1);
 
     private static final String TAG = "com.amplitude.api.DatabaseHelper";
 
@@ -50,16 +52,18 @@ class DatabaseHelper extends SQLiteOpenHelper {
 
     private static final AmplitudeLog logger = AmplitudeLog.getLogger();
 
-    static synchronized DatabaseHelper getDatabaseHelper(Context context) {
+    static synchronized DatabaseHelper getDatabaseHelper(Context context, String key) {
+        DatabaseHelper instance = instances.get(key);
         if (instance == null) {
-            instance = new DatabaseHelper(context.getApplicationContext());
+            instance = new DatabaseHelper(context.getApplicationContext(), key);
+            instances.put(key, instance);
         }
         return instance;
     }
 
-    protected DatabaseHelper(Context context) {
-        super(context, Constants.DATABASE_NAME, null, Constants.DATABASE_VERSION);
-        file = context.getDatabasePath(Constants.DATABASE_NAME);
+    protected DatabaseHelper(Context context, String key) {
+        super(context, Constants.DATABASE_NAME + "." + key, null, Constants.DATABASE_VERSION);
+        file = context.getDatabasePath(Constants.DATABASE_NAME + "." + key);
     }
 
     @Override

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -57,7 +57,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testSetUserId() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         String userId = "user_id";
         amplitude.setUserId(userId);
@@ -101,7 +101,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testSetDeviceId() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         looper.runToEndOfTasks();
 
@@ -238,7 +238,7 @@ public class AmplitudeClientTest extends BaseTest {
     public void testReloadDeviceIdFromDatabase() {
         String deviceId = "test_device_id";
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
-        DatabaseHelper.getDatabaseHelper(context).insertOrReplaceKeyValue(
+        DatabaseHelper.getDatabaseHelper(context, apiKey).insertOrReplaceKeyValue(
                 AmplitudeClient.DEVICE_ID_KEY,
                 deviceId
         );
@@ -262,7 +262,7 @@ public class AmplitudeClientTest extends BaseTest {
         looper.getScheduler().advanceToLastPostedRunnable();
         String deviceId = amplitude.getDeviceId();
         assertTrue(deviceId.endsWith("R"));
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertEquals(
                 deviceId,
                 dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY)
@@ -277,7 +277,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(37, amplitude.getDeviceId().length());
         String deviceId = amplitude.getDeviceId();
         assertTrue(deviceId.endsWith("R"));
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertEquals(
                 deviceId,
                 dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY)
@@ -289,7 +289,7 @@ public class AmplitudeClientTest extends BaseTest {
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         ShadowLooper httplooper = Shadows.shadowOf(amplitude.httpThread.getLooper());
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertFalse(amplitude.isOptedOut());
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY), 0L);
 
@@ -365,7 +365,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertTrue(Utils.compareJSONObjects(userProperties.getJSONObject(Constants.AMP_OP_SET), expected));
 
         // verify db state
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertNull(dbHelper.getValue(AmplitudeClient.USER_ID_KEY));
         assertEquals((long)dbHelper.getLongValue(AmplitudeClient.LAST_IDENTIFY_ID_KEY), 1L);
         assertEquals((long)dbHelper.getLongValue(AmplitudeClient.LAST_EVENT_ID_KEY), -1L);
@@ -610,7 +610,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(getUnsentIdentifyCount(), 0);
 
         // verify db state
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertNull(dbHelper.getValue(AmplitudeClient.USER_ID_KEY));
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.LAST_IDENTIFY_ID_KEY), 3L);
         assertEquals((long) dbHelper.getLongValue(AmplitudeClient.LAST_EVENT_ID_KEY), 4L);
@@ -642,7 +642,7 @@ public class AmplitudeClientTest extends BaseTest {
         event.remove("sequence_number");
         event.remove("event_id");
         // delete event from db and reinsert modified event
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.removeEvent(1);
         dbHelper.addEvent(event.toString());
         amplitude.uploadingCurrently.set(false);
@@ -975,7 +975,7 @@ public class AmplitudeClientTest extends BaseTest {
         clock.setTimestamps(timestamps);
         Robolectric.getForegroundThreadScheduler().advanceTo(1);
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         looper.runToEndOfTasks();
         assertEquals(getUnsentEventCount(), 0);
@@ -1160,7 +1160,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testAutoIncrementSequenceNumber() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         int limit = 10;
         for (int i = 0; i < limit; i++) {
             assertEquals(amplitude.getNextSequenceNumber(), i+1);
@@ -1197,7 +1197,7 @@ public class AmplitudeClientTest extends BaseTest {
         clock.setTimestamps(timestamps);
         Robolectric.getForegroundThreadScheduler().advanceTo(1);
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         int eventMaxCount = 3;
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         amplitude.setEventMaxCount(eventMaxCount).setOffline(true);
@@ -1233,7 +1233,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testTruncateEventsQueues() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         int eventMaxCount = 50;
         assertTrue(eventMaxCount > Constants.EVENT_REMOVE_BATCH_SIZE);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
@@ -1252,7 +1252,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testTruncateEventsQueuesWithOneEvent() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         int eventMaxCount = 1;
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
         amplitude.setEventMaxCount(eventMaxCount).setOffline(true);
@@ -1392,7 +1392,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(getUnsentIdentifyCount(), 0);
 
         // mock out database helper to force CursorWindowAllocationExceptions
-        DatabaseHelper.instance = new MockDatabaseHelper(context);
+        DatabaseHelper.instances.put(apiKey, new MockDatabaseHelper(context));
 
         // force an upload and verify no request sent
         // make sure we catch it during sending of events and defer sending
@@ -1478,7 +1478,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testRegenerateDeviceId() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         String oldDeviceId = amplitude.getDeviceId();
         assertEquals(oldDeviceId, dbHelper.getValue("device_id"));
 
@@ -1492,7 +1492,7 @@ public class AmplitudeClientTest extends BaseTest {
 
     @Test
     public void testSendNullEvents() throws JSONException {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
 
         dbHelper.addEvent(null);

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -56,7 +56,7 @@ public class BaseTest {
     protected class MockDatabaseHelper extends DatabaseHelper {
 
         protected MockDatabaseHelper(Context context) {
-            super(context);
+            super(context, apiKey);
         }
 
         @Override
@@ -91,7 +91,7 @@ public class BaseTest {
         // Clear the database helper for each test. Better to have isolation.
         // See https://github.com/robolectric/robolectric/issues/569
         // and https://github.com/robolectric/robolectric/issues/1622
-        DatabaseHelper.instance = null;
+        DatabaseHelper.instances.clear();
 
         if (withServer) {
             server = new MockWebServer();
@@ -125,7 +125,7 @@ public class BaseTest {
             server.shutdown();
         }
 
-        DatabaseHelper.instance = null;
+        DatabaseHelper.instances.clear();
     }
 
     public RecordedRequest runRequest(AmplitudeClient amplitude) {
@@ -159,11 +159,11 @@ public class BaseTest {
     }
 
     public long getUnsentEventCount() {
-        return DatabaseHelper.getDatabaseHelper(context).getEventCount();
+        return DatabaseHelper.getDatabaseHelper(context, apiKey).getEventCount();
     }
 
     public long getUnsentIdentifyCount() {
-        return DatabaseHelper.getDatabaseHelper(context).getIdentifyCount();
+        return DatabaseHelper.getDatabaseHelper(context, apiKey).getIdentifyCount();
     }
 
 
@@ -187,7 +187,7 @@ public class BaseTest {
 
     public JSONArray getUnsentEventsFromTable(String table, int limit) {
         try {
-            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
             List<JSONObject> events = table.equals(DatabaseHelper.IDENTIFY_TABLE_NAME) ?
                     dbHelper.getIdentifys(-1, -1) : dbHelper.getEvents(-1, -1);
 
@@ -214,7 +214,7 @@ public class BaseTest {
 
     public JSONObject getLastEventFromTable(String table) {
         try {
-            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+            DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
             List<JSONObject> events = table.equals(DatabaseHelper.IDENTIFY_TABLE_NAME) ?
                     dbHelper.getIdentifys(-1, -1) : dbHelper.getEvents(-1, -1);
             return events.get(events.size() - 1);

--- a/test/com/amplitude/api/DatabaseHelperTest.java
+++ b/test/com/amplitude/api/DatabaseHelperTest.java
@@ -28,7 +28,7 @@ public class DatabaseHelperTest extends BaseTest {
         super.setUp(false);
         amplitude.initialize(context, apiKey);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runOneTask();
-        dbInstance = DatabaseHelper.getDatabaseHelper(context);
+        dbInstance = DatabaseHelper.getDatabaseHelper(context, apiKey);
     }
 
     @After

--- a/test/com/amplitude/api/InitializeTest.java
+++ b/test/com/amplitude/api/InitializeTest.java
@@ -44,7 +44,7 @@ public class InitializeTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_USER_ID, "oldestUserId").commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyValue(AmplitudeClient.USER_ID_KEY, "oldUserId");
 
         String userId = "newUserId";
@@ -73,7 +73,7 @@ public class InitializeTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_USER_ID, userId).commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertNull(dbHelper.getValue(AmplitudeClient.USER_ID_KEY));
 
         amplitude.initialize(context, apiKey);
@@ -95,7 +95,7 @@ public class InitializeTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_USER_ID, "oldUserId").commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyValue(AmplitudeClient.USER_ID_KEY, userId);
 
         amplitude.initialize(context, apiKey);
@@ -117,7 +117,7 @@ public class InitializeTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         assertNull(dbHelper.getLongValue(AmplitudeClient.OPT_OUT_KEY));
 
         amplitude.initialize(context, apiKey);
@@ -141,7 +141,7 @@ public class InitializeTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.OPT_OUT_KEY, 0L);
 
         amplitude.initialize(context, apiKey);
@@ -157,7 +157,7 @@ public class InitializeTest extends BaseTest {
 
     @Test
     public void testInitializeLastEventId() throws JSONException {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
 
         String sourceName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
@@ -187,7 +187,7 @@ public class InitializeTest extends BaseTest {
 
     @Test
     public void testInitializePreviousSessionId() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
 
         String sourceName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
@@ -205,7 +205,7 @@ public class InitializeTest extends BaseTest {
 
     @Test
     public void testInitializeLastEventTime() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.LAST_EVENT_TIME_KEY, 5000L);
 
         String sourceName = Constants.PACKAGE_NAME + "." + context.getPackageName();
@@ -224,7 +224,7 @@ public class InitializeTest extends BaseTest {
 
     @Test
     public void testSkipSharedPrefsToDb() {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyValue(AmplitudeClient.DEVICE_ID_KEY, "testDeviceId");
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.PREVIOUS_SESSION_ID_KEY, 1000L);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.LAST_EVENT_TIME_KEY, 2000L);
@@ -280,7 +280,7 @@ public class InitializeTest extends BaseTest {
         prefs.edit().putLong(Constants.PREFKEY_PREVIOUS_SESSION_ID, 6000L).commit();
         prefs.edit().putLong(Constants.PREFKEY_LAST_EVENT_TIME, 6000L).commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.LAST_EVENT_TIME_KEY, 7000L);
 
         long [] timestamps = {8000, 14000};

--- a/test/com/amplitude/api/UpgradePrefsTest.java
+++ b/test/com/amplitude/api/UpgradePrefsTest.java
@@ -106,9 +106,9 @@ public class UpgradePrefsTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_DEVICE_ID, deviceId).commit();
 
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
         assertEquals(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY),
+            DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(AmplitudeClient.DEVICE_ID_KEY),
             deviceId
         );
 
@@ -118,9 +118,9 @@ public class UpgradePrefsTest extends BaseTest {
 
     @Test
     public void testUpgradeDeviceIdToDBEmpty() {
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
         assertNull(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
+            DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(AmplitudeClient.DEVICE_ID_KEY)
         );
     }
 
@@ -134,12 +134,12 @@ public class UpgradePrefsTest extends BaseTest {
                 .commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
         assertEquals(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY),
+            DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(AmplitudeClient.DEVICE_ID_KEY),
             deviceId
         );
 
@@ -156,13 +156,13 @@ public class UpgradePrefsTest extends BaseTest {
                 .commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
         assertNull(target.getString(Constants.PREFKEY_DEVICE_ID, null));
         assertNull(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.DEVICE_ID_KEY)
+            DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(AmplitudeClient.DEVICE_ID_KEY)
         );
     }
 
@@ -172,9 +172,9 @@ public class UpgradePrefsTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
 
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
         assertEquals(
-            (long) DatabaseHelper.getDatabaseHelper(context).getLongValue(
+            (long) DatabaseHelper.getDatabaseHelper(context, apiKey).getLongValue(
                 AmplitudeClient.OPT_OUT_KEY
             ), 1L
         );
@@ -190,12 +190,12 @@ public class UpgradePrefsTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
 
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.OPT_OUT_KEY, 0L);
 
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
         assertEquals(
-            (long) DatabaseHelper.getDatabaseHelper(context).getLongValue(
+            (long) DatabaseHelper.getDatabaseHelper(context, apiKey).getLongValue(
                 AmplitudeClient.OPT_OUT_KEY
             ), 0L
         );
@@ -213,13 +213,13 @@ public class UpgradePrefsTest extends BaseTest {
                 .commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
         assertFalse(target.getBoolean(Constants.PREFKEY_DEVICE_ID, false));
         assertEquals(
-            (long) DatabaseHelper.getDatabaseHelper(context).getLongValue(
+            (long) DatabaseHelper.getDatabaseHelper(context, apiKey).getLongValue(
                 AmplitudeClient.OPT_OUT_KEY
             ), 1L
         );
@@ -231,9 +231,9 @@ public class UpgradePrefsTest extends BaseTest {
         SharedPreferences prefs = context.getSharedPreferences(sourceName, Context.MODE_PRIVATE);
         prefs.edit().putString(Constants.PREFKEY_USER_ID, "testUserId").commit();
 
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
         assertEquals(
-            DatabaseHelper.getDatabaseHelper(context).getValue(AmplitudeClient.USER_ID_KEY),
+            DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(AmplitudeClient.USER_ID_KEY),
             "testUserId"
         );
 
@@ -249,12 +249,12 @@ public class UpgradePrefsTest extends BaseTest {
                 .putString(legacyPkgName + ".userId", "testUserId2").commit();
 
         assertTrue(AmplitudeClient.upgradePrefs(context, legacyPkgName, null));
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
 
         String targetName = Constants.PACKAGE_NAME + "." + context.getPackageName();
         SharedPreferences target = context.getSharedPreferences(targetName, Context.MODE_PRIVATE);
         assertNull(target.getString(Constants.PREFKEY_USER_ID, null));
-        assertEquals(DatabaseHelper.getDatabaseHelper(context).getValue(
+        assertEquals(DatabaseHelper.getDatabaseHelper(context, apiKey).getValue(
             AmplitudeClient.USER_ID_KEY
         ), "testUserId2");
     }
@@ -262,7 +262,7 @@ public class UpgradePrefsTest extends BaseTest {
     @Test
     public void testSkipUpgradeSharedPrefsToDb() {
         // skips if DB already has deviceId, previous session id, and last event time
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context, apiKey);
         dbHelper.insertOrReplaceKeyValue(AmplitudeClient.DEVICE_ID_KEY, "testDeviceId");
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.PREVIOUS_SESSION_ID_KEY, 1000L);
         dbHelper.insertOrReplaceKeyLongValue(AmplitudeClient.LAST_EVENT_TIME_KEY, 2000L);
@@ -279,7 +279,7 @@ public class UpgradePrefsTest extends BaseTest {
         prefs.edit().putBoolean(Constants.PREFKEY_OPT_OUT, true).commit();
         prefs.edit().putLong(Constants.PREFKEY_LAST_IDENTIFY_ID, 3000L).commit();
 
-        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context));
+        assertTrue(AmplitudeClient.upgradeSharedPrefsToDB(context, "dummy"));
 
         // after upgrade, pref values still there since they weren't deleted
         assertEquals(dbHelper.getValue(AmplitudeClient.DEVICE_ID_KEY), "testDeviceId");


### PR DESCRIPTION
**Problem**: we maintain an Android library that we share between apps in our company that we wish to produce its own tracking with Amplitude SDK. The problem is that because Amplitude SDK only works with one app at a time, if an app using this library *also* uses Amplitude SDK tracking, as soon as our library code is started it will "take over" the logging of events, stopping the flow of events for the hosting app's API key.

**Solution**
With this change, the singleton approach to Amplitude SDK should work completely unchanged – this change is backwards-compatible. In order to have multiple Amplitude apps (API keys) in a single app, you can use the public constructor for AmplitudeClient and retain a reference to it in wrapper code in your app and/or library.

For example:

```
amplitudeClient = new AmplitudeClient();
amplitudeClient.initialize(app, apiKey).enableForegroundTracking(app);
```
...later...
```
amplitudeClient.setUserId(realmId);
amplitudeClient.logEvent(eventName, new JSONObject(properties));
```

The AmplitudeClient class was already written in such a way as not to depend on being a singleton: the only heavy lifting that was necessary in this pull request was to have each client depend on a separate  SQLite DB. (Otherwise events would "bleed" across instances.)

It would also be easy to make the ```getInstance()``` accept a key string as well, though using the apiKey as the DB name key seemed a sensible way to handle this. (It will prevent you from instantiating the same app twice.)

Please consider this for integration, it solves a real problem we are facing now.

Thanks!
