### PR TITLE
Catch more exceptions from TelephonyManager

### DIFF
--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -102,9 +102,14 @@ public class DeviceInfo {
         }
 
         private String getCarrier() {
-            TelephonyManager manager = (TelephonyManager) context
-                    .getSystemService(Context.TELEPHONY_SERVICE);
-            return manager.getNetworkOperatorName();
+            try {
+                TelephonyManager manager = (TelephonyManager) context
+                        .getSystemService(Context.TELEPHONY_SERVICE);
+                return manager.getNetworkOperatorName();
+            } catch (Exception e) {
+                // Failed to get network operator name from network
+            }
+            return null;
         }
 
         private String getCountry() {


### PR DESCRIPTION
I've come across exceptions in `getCarrier` when initializing the Amplitude client. This change handles this in the same way as `getCountryFromNetwork`.