### PR TITLE
copy userproperties on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Handle exceptions when fetching device carrier information. Thanks to @fkam-tt for the pull request.
+* Copy userProperties on main thread in `setUserProperties` to prevent ConcurrentModificationExceptions.
 * Migrating setup instructions and SDK documentation in the README file to Zendesk articles.
 
 ## 2.13.3 (March 13, 2017)

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1296,41 +1296,23 @@ public class AmplitudeClient {
             return;
         }
 
-        runOnLogThread(new Runnable() {
-            @Override
-            public void run() {
-                if (TextUtils.isEmpty(apiKey)) {  // in case initialization failed
-                    return;
-                }
+        // sanitize and truncate properties before trying to convert to identify
+        JSONObject sanitized = truncate(userProperties);
+        if (sanitized.length() == 0) {
+            return;
+        }
 
-                // Create deep copy to try and prevent ConcurrentModificationException
-                JSONObject copy;
-                try {
-                    copy = new JSONObject(userProperties.toString());
-                } catch (JSONException e) {
-                    logger.e(TAG, e.toString());
-                    return; // could not create copy
-                }
-
-                // sanitize and truncate properties before trying to convert to identify
-                JSONObject sanitized = truncate(copy);
-                if (sanitized.length() == 0) {
-                    return;
-                }
-
-                Identify identify = new Identify();
-                Iterator<?> keys = sanitized.keys();
-                while (keys.hasNext()) {
-                    String key = (String) keys.next();
-                    try {
-                        identify.setUserProperty(key, sanitized.get(key));
-                    } catch (JSONException e) {
-                        logger.e(TAG, e.toString());
-                    }
-                }
-                identify(identify);
+        Identify identify = new Identify();
+        Iterator<?> keys = sanitized.keys();
+        while (keys.hasNext()) {
+            String key = (String) keys.next();
+            try {
+                identify.setUserProperty(key, sanitized.get(key));
+            } catch (JSONException e) {
+                logger.e(TAG, e.toString());
             }
-        });
+        }
+        identify(identify);
     }
 
     /**


### PR DESCRIPTION
`setUserProperties` should follow `logEvent` in that the userProperties are cloned (shallow) on the main thread, before being passed to the logic on the background thread. That prevents ConcurrentModificationExceptions. Also, since setUserProperties calls `identify` which handles the background logic, there's no need to run any of the function logic on the background thread.