### PR TITLE
add support for multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add support for logging events to multiple Amplitude apps. See our [Help Center Documentation](https://amplitude.zendesk.com/hc/en-us/articles/115002935588#logging-events-to-multiple-projects) for details.
+
 ## 2.13.4 (May 09, 2017)
 
 * Handle exceptions when fetching device carrier information. Thanks to @fkam-tt for the pull request.

--- a/src/com/amplitude/api/Amplitude.java
+++ b/src/com/amplitude/api/Amplitude.java
@@ -1,7 +1,6 @@
 package com.amplitude.api;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import org.json.JSONObject;
 
@@ -38,12 +37,8 @@ public class Amplitude {
      * @param instance name to get "ex app 1"
      * @return the specified instance
      */
-    public static synchronized  AmplitudeClient getInstance(String instance) {
-        if (TextUtils.isEmpty(instance)) {
-            instance = Constants.DEFAULT_INSTANCE;
-        }
-        instance = instance.toLowerCase();
-
+    public static synchronized AmplitudeClient getInstance(String instance) {
+        instance = Utils.normalizeInstanceName(instance);
         AmplitudeClient client = instances.get(instance);
         if (client == null) {
             client = new AmplitudeClient(instance);

--- a/src/com/amplitude/api/Amplitude.java
+++ b/src/com/amplitude/api/Amplitude.java
@@ -1,8 +1,12 @@
 package com.amplitude.api;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -16,14 +20,36 @@ import org.json.JSONObject;
  */
 public class Amplitude {
 
+    static final Map<String, AmplitudeClient> instances = new HashMap<String, AmplitudeClient>();
+
     /**
-     * Gets the default instance. This is the only method you should be calling on the
-     * Amplitude class.
+     * Gets the default instance.
      *
      * @return the default instance
      */
     public static AmplitudeClient getInstance() {
-        return AmplitudeClient.getInstance();
+        return getInstance(null);
+    }
+
+    /**
+     * Gets the specified instance. If instance is null or empty string, fetches the default
+     * instance instead.
+     *
+     * @param instance name to get "ex app 1"
+     * @return the specified instance
+     */
+    public static synchronized  AmplitudeClient getInstance(String instance) {
+        if (TextUtils.isEmpty(instance)) {
+            instance = Constants.DEFAULT_INSTANCE;
+        }
+        instance = instance.toLowerCase();
+
+        AmplitudeClient client = instances.get(instance);
+        if (client == null) {
+            client = new AmplitudeClient(instance);
+            instances.put(instance, client);
+        }
+        return client;
     }
 
     /**

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -185,10 +185,7 @@ public class AmplitudeClient {
      * @param instance
      */
     public AmplitudeClient(String instance) {
-        if (TextUtils.isEmpty(instance)) {
-            instance = Constants.DEFAULT_INSTANCE;
-        }
-        this.instanceName = instance.toLowerCase();
+        this.instanceName = Utils.normalizeInstanceName(instance);
         logThread.start();
         httpThread.start();
     }

--- a/src/com/amplitude/api/Constants.java
+++ b/src/com/amplitude/api/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
     public static final String DATABASE_NAME = PACKAGE_NAME;
     public static final int DATABASE_VERSION = 3;
 
+    public static final String DEFAULT_INSTANCE = "$default_instance";
+
     public static final int EVENT_UPLOAD_THRESHOLD = 30;
     public static final int EVENT_UPLOAD_MAX_BATCH_SIZE = 100;
     public static final int EVENT_MAX_COUNT = 1000;

--- a/src/com/amplitude/api/DatabaseHelper.java
+++ b/src/com/amplitude/api/DatabaseHelper.java
@@ -54,38 +54,32 @@ class DatabaseHelper extends SQLiteOpenHelper {
     private static final AmplitudeLog logger = AmplitudeLog.getLogger();
 
     @Deprecated
-    static synchronized DatabaseHelper getDatabaseHelper(Context context) {
+    static DatabaseHelper getDatabaseHelper(Context context) {
         return getDatabaseHelper(context, null);
     }
 
     static synchronized DatabaseHelper getDatabaseHelper(Context context, String instance) {
-        if (TextUtils.isEmpty(instance)) {
-            instance = Constants.DEFAULT_INSTANCE;
-        }
-        instance = instance.toLowerCase();
-
+        instance = Utils.normalizeInstanceName(instance);
         DatabaseHelper dbHelper = instances.get(instance);
         if (dbHelper == null) {
-            if (instance.equalsIgnoreCase(Constants.DEFAULT_INSTANCE)) {
-                dbHelper = new DatabaseHelper(context.getApplicationContext());
-            } else {
-                dbHelper = new DatabaseHelper(context.getApplicationContext(), instance);
-            }
+            dbHelper = new DatabaseHelper(context.getApplicationContext(), instance);
             instances.put(instance, dbHelper);
         }
         return dbHelper;
     }
 
+    private static String getDatabaseName(String instance) {
+        return (TextUtils.isEmpty(instance) || instance.equals(Constants.DEFAULT_INSTANCE)) ? Constants.DATABASE_NAME : Constants.DATABASE_NAME + "_" + instance;
+    }
+
     protected DatabaseHelper(Context context) {
-        super(context, Constants.DATABASE_NAME, null, Constants.DATABASE_VERSION);
-        file = context.getDatabasePath(Constants.DATABASE_NAME);
-        instanceName = Constants.DEFAULT_INSTANCE;
+        this(context, null);
     }
 
     protected DatabaseHelper(Context context, String instance) {
-        super(context, Constants.DATABASE_NAME + "_" + instance, null, Constants.DATABASE_VERSION);
-        file = context.getDatabasePath(Constants.DATABASE_NAME + "_" + instance);
-        instanceName = instance;
+        super(context, getDatabaseName(instance), null, Constants.DATABASE_VERSION);
+        file = context.getDatabasePath(getDatabaseName(instance));
+        instanceName = Utils.normalizeInstanceName(instance);
     }
 
     @Override

--- a/src/com/amplitude/api/PinnedAmplitudeClient.java
+++ b/src/com/amplitude/api/PinnedAmplitudeClient.java
@@ -1,7 +1,6 @@
 package com.amplitude.api;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -181,11 +180,7 @@ public class PinnedAmplitudeClient extends AmplitudeClient {
      * @return the specified instance
      */
     public static synchronized PinnedAmplitudeClient getInstance(String instance) {
-        if (TextUtils.isEmpty(instance)) {
-            instance = Constants.DEFAULT_INSTANCE;
-        }
-        instance = instance.toLowerCase();
-
+        instance = Utils.normalizeInstanceName(instance);
         PinnedAmplitudeClient client = instances.get(instance);
         if (client == null) {
             client = new PinnedAmplitudeClient(instance);

--- a/src/com/amplitude/api/PinnedAmplitudeClient.java
+++ b/src/com/amplitude/api/PinnedAmplitudeClient.java
@@ -1,6 +1,7 @@
 package com.amplitude.api;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -8,7 +9,9 @@ import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -159,18 +162,36 @@ public class PinnedAmplitudeClient extends AmplitudeClient {
         }
     }
 
-    /**
-     * The default instance.
-     */
-    protected static PinnedAmplitudeClient instance = new PinnedAmplitudeClient();
+    static Map<String, PinnedAmplitudeClient> instances = new HashMap<String, PinnedAmplitudeClient>();
 
     /**
-     * Gets the default instance. Call SDK method on the default instance.
+     * Gets the default instance.
      *
      * @return the default instance
      */
     public static PinnedAmplitudeClient getInstance() {
-        return instance;
+        return getInstance(null);
+    }
+
+    /**
+     * Gets the specified instance. If instance is null or empty string, fetches the default
+     * instance instead.
+     *
+     * @param instance name to get "ex app 1"
+     * @return the specified instance
+     */
+    public static synchronized PinnedAmplitudeClient getInstance(String instance) {
+        if (TextUtils.isEmpty(instance)) {
+            instance = Constants.DEFAULT_INSTANCE;
+        }
+        instance = instance.toLowerCase();
+
+        PinnedAmplitudeClient client = instances.get(instance);
+        if (client == null) {
+            client = new PinnedAmplitudeClient(instance);
+            instances.put(instance, client);
+        }
+        return client;
     }
 
     /**
@@ -181,8 +202,8 @@ public class PinnedAmplitudeClient extends AmplitudeClient {
     /**
      * Instantiates a new Pinned amplitude client.
      */
-    public PinnedAmplitudeClient() {
-        super();
+    public PinnedAmplitudeClient(String instance) {
+        super(instance);
     }
 
     /**

--- a/src/com/amplitude/api/Utils.java
+++ b/src/com/amplitude/api/Utils.java
@@ -1,5 +1,7 @@
 package com.amplitude.api;
 
+import android.text.TextUtils;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -87,5 +89,12 @@ public class Utils {
             return true;
         } catch (JSONException e) {}
         return false;
+    }
+
+    static String normalizeInstanceName(String instance) {
+        if (TextUtils.isEmpty(instance)) {
+            instance = Constants.DEFAULT_INSTANCE;
+        }
+        return instance.toLowerCase();
     }
 }

--- a/test/com/amplitude/api/AmplitudeClientTest.java
+++ b/test/com/amplitude/api/AmplitudeClientTest.java
@@ -56,6 +56,16 @@ public class AmplitudeClientTest extends BaseTest {
     }
 
     @Test
+    public void testConstructor() {
+        // verify that the constructor lowercases the instance name
+        AmplitudeClient a = new AmplitudeClient("APP1");
+        AmplitudeClient b = new AmplitudeClient("New_App_2");
+
+        assertEquals(a.instanceName, "app1");
+        assertEquals(b.instanceName, "new_app_2");
+    }
+
+    @Test
     public void testSetUserId() {
         DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper(context);
         ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
@@ -1392,7 +1402,7 @@ public class AmplitudeClientTest extends BaseTest {
         assertEquals(getUnsentIdentifyCount(), 0);
 
         // mock out database helper to force CursorWindowAllocationExceptions
-        DatabaseHelper.instance = new MockDatabaseHelper(context);
+        DatabaseHelper.instances.put(Constants.DEFAULT_INSTANCE, new MockDatabaseHelper(context));
 
         // force an upload and verify no request sent
         // make sure we catch it during sending of events and defer sending

--- a/test/com/amplitude/api/AmplitudeTest.java
+++ b/test/com/amplitude/api/AmplitudeTest.java
@@ -1,0 +1,193 @@
+package com.amplitude.api;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AmplitudeTest extends BaseTest {
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    public void testGetInstance() {
+        AmplitudeClient a = Amplitude.getInstance();
+        AmplitudeClient b = Amplitude.getInstance("");
+        AmplitudeClient c = Amplitude.getInstance(null);
+        AmplitudeClient d = Amplitude.getInstance(Constants.DEFAULT_INSTANCE);
+        AmplitudeClient e = Amplitude.getInstance("app1");
+        AmplitudeClient f = Amplitude.getInstance("app2");
+
+        assertSame(a, b);
+        assertSame(b, c);
+        assertSame(c, d);
+        assertSame(d, Amplitude.getInstance());
+        assertNotSame(d, e);
+        assertSame(e, Amplitude.getInstance("app1"));
+        assertNotSame(e, f);
+        assertSame(f, Amplitude.getInstance("app2"));
+
+        // test for instance name case insensitivity
+        assertSame(e, Amplitude.getInstance("APP1"));
+        assertSame(e, Amplitude.getInstance("App1"));
+        assertSame(e, Amplitude.getInstance("aPP1"));
+        assertSame(e, Amplitude.getInstance("apP1"));
+
+        assertTrue(Amplitude.instances.size() == 3);
+        assertTrue(Amplitude.instances.containsKey(Constants.DEFAULT_INSTANCE));
+        assertTrue(Amplitude.instances.containsKey("app1"));
+        assertTrue(Amplitude.instances.containsKey("app2"));
+    }
+
+    @Test
+    public void testSeparateInstancesLogEventsSeparately() {
+        Amplitude.instances.clear();
+        DatabaseHelper.instances.clear();
+
+        String newInstance1 = "newApp1";
+        String newApiKey1 = "1234567890";
+        String newInstance2 = "newApp2";
+        String newApiKey2 = "0987654321";
+
+        DatabaseHelper oldDbHelper = DatabaseHelper.getDatabaseHelper(context);
+        DatabaseHelper newDbHelper1 = DatabaseHelper.getDatabaseHelper(context, newInstance1);
+        DatabaseHelper newDbHelper2 = DatabaseHelper.getDatabaseHelper(context, newInstance2);
+
+        // Setup existing Databasefile
+        oldDbHelper.insertOrReplaceKeyValue("device_id", "oldDeviceId");
+        oldDbHelper.insertOrReplaceKeyLongValue("sequence_number", 1000L);
+        oldDbHelper.addEvent("oldEvent1");
+        oldDbHelper.addIdentify("oldIdentify1");
+        oldDbHelper.addIdentify("oldIdentify2");
+
+        // Verify persistence of old database file in default instance
+        Amplitude.getInstance().initialize(context, apiKey);
+        Shadows.shadowOf(Amplitude.getInstance().logThread.getLooper()).runToEndOfTasks();
+        assertEquals(Amplitude.getInstance().getDeviceId(), "oldDeviceId");
+        assertEquals(Amplitude.getInstance().getNextSequenceNumber(), 1001L);
+        assertTrue(oldDbHelper.dbFileExists());
+        assertFalse(newDbHelper1.dbFileExists());
+        assertFalse(newDbHelper2.dbFileExists());
+
+        // init first new app and verify separate database file
+        Amplitude.getInstance(newInstance1).initialize(context, newApiKey1);
+        Shadows.shadowOf(
+            Amplitude.getInstance(newInstance1).logThread.getLooper()
+        ).runToEndOfTasks();
+        assertTrue(newDbHelper1.dbFileExists()); // db file is created after deviceId initialization
+
+        assertFalse(newDbHelper1.getValue("device_id").equals("oldDeviceId"));
+        assertEquals(
+            newDbHelper1.getValue("device_id"), Amplitude.getInstance(newInstance1).getDeviceId()
+        );
+        assertEquals(Amplitude.getInstance(newInstance1).getNextSequenceNumber(), 1L);
+        assertEquals(newDbHelper1.getEventCount(), 0);
+        assertEquals(newDbHelper1.getIdentifyCount(), 0);
+
+        // init second new app and verify separate database file
+        Amplitude.getInstance(newInstance2).initialize(context, newApiKey2);
+        Shadows.shadowOf(
+            Amplitude.getInstance(newInstance2).logThread.getLooper()
+        ).runToEndOfTasks();
+        assertTrue(newDbHelper2.dbFileExists()); // db file is created after deviceId initialization
+
+        assertFalse(newDbHelper2.getValue("device_id").equals("oldDeviceId"));
+        assertEquals(
+            newDbHelper2.getValue("device_id"), Amplitude.getInstance(newInstance2).getDeviceId()
+        );
+        assertEquals(Amplitude.getInstance(newInstance2).getNextSequenceNumber(), 1L);
+        assertEquals(newDbHelper2.getEventCount(), 0);
+        assertEquals(newDbHelper2.getIdentifyCount(), 0);
+
+        // verify existing database still intact
+        assertTrue(oldDbHelper.dbFileExists());
+        assertEquals(oldDbHelper.getValue("device_id"), "oldDeviceId");
+        assertEquals(oldDbHelper.getLongValue("sequence_number").longValue(), 1001L);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        // verify both apps can modify their database independently and not affect old database
+        newDbHelper1.insertOrReplaceKeyValue("device_id", "fakeDeviceId");
+        assertEquals(newDbHelper1.getValue("device_id"), "fakeDeviceId");
+        assertFalse(newDbHelper2.getValue("device_id").equals("fakeDeviceId"));
+        assertEquals(oldDbHelper.getValue("device_id"), "oldDeviceId");
+        newDbHelper1.addIdentify("testIdentify3");
+        assertEquals(newDbHelper1.getIdentifyCount(), 1);
+        assertEquals(newDbHelper2.getIdentifyCount(), 0);
+        assertEquals(oldDbHelper.getIdentifyCount(), 2);
+
+        newDbHelper2.insertOrReplaceKeyValue("device_id", "brandNewDeviceId");
+        assertEquals(newDbHelper1.getValue("device_id"), "fakeDeviceId");
+        assertEquals(newDbHelper2.getValue("device_id"), "brandNewDeviceId");
+        assertEquals(oldDbHelper.getValue("device_id"), "oldDeviceId");
+        newDbHelper2.addEvent("testEvent2");
+        newDbHelper2.addEvent("testEvent3");
+        assertEquals(newDbHelper1.getEventCount(), 0);
+        assertEquals(newDbHelper2.getEventCount(), 2);
+        assertEquals(oldDbHelper.getEventCount(), 1);
+    }
+
+    @Test
+    public void testSeparateInstancesSeparateSharedPreferences() {
+        // set up existing preferences values for default instance
+        long timestamp = System.currentTimeMillis();
+        String prefName = Constants.SHARED_PREFERENCES_NAME_PREFIX + "." + context.getPackageName();
+        SharedPreferences preferences = context.getSharedPreferences(
+            prefName, Context.MODE_PRIVATE);
+        preferences.edit().putLong(Constants.PREFKEY_LAST_EVENT_ID, 1000L).commit();
+        preferences.edit().putLong(Constants.PREFKEY_LAST_EVENT_TIME, timestamp).commit();
+        preferences.edit().putLong(Constants.PREFKEY_LAST_IDENTIFY_ID, 2000L).commit();
+        preferences.edit().putLong(Constants.PREFKEY_PREVIOUS_SESSION_ID, timestamp).commit();
+
+        // init default instance, which should load preferences values
+        Amplitude.getInstance().initialize(context, apiKey);
+        Shadows.shadowOf(Amplitude.getInstance().logThread.getLooper()).runToEndOfTasks();
+        assertEquals(Amplitude.getInstance().lastEventId, 1000L);
+        assertEquals(Amplitude.getInstance().lastEventTime, timestamp);
+        assertEquals(Amplitude.getInstance().lastIdentifyId, 2000L);
+        assertEquals(Amplitude.getInstance().previousSessionId, timestamp);
+
+        // init new instance, should have blank slate
+        Amplitude.getInstance("new_app").initialize(context, "1234567890");
+        Shadows.shadowOf(Amplitude.getInstance("new_app").logThread.getLooper()).runToEndOfTasks();
+        assertEquals(Amplitude.getInstance("new_app").lastEventId, -1L);
+        assertEquals(Amplitude.getInstance("new_app").lastEventTime, -1L);
+        assertEquals(Amplitude.getInstance("new_app").lastIdentifyId, -1L);
+        assertEquals(Amplitude.getInstance("new_app").previousSessionId, -1L);
+
+        // shared preferences should update independently
+        Amplitude.getInstance("new_app").logEvent("testEvent");
+        Shadows.shadowOf(Amplitude.getInstance("new_app").logThread.getLooper()).runToEndOfTasks();
+        assertEquals(Amplitude.getInstance("new_app").lastEventId, 1L);
+        assertTrue(Amplitude.getInstance("new_app").lastEventTime > timestamp);
+        assertEquals(Amplitude.getInstance("new_app").lastIdentifyId, -1L);
+        assertTrue(Amplitude.getInstance("new_app").previousSessionId > timestamp);
+
+        assertEquals(Amplitude.getInstance().lastEventId, 1000L);
+        assertEquals(Amplitude.getInstance().lastEventTime, timestamp);
+        assertEquals(Amplitude.getInstance().lastIdentifyId, 2000L);
+        assertEquals(Amplitude.getInstance().previousSessionId, timestamp);
+    }
+}

--- a/test/com/amplitude/api/BaseTest.java
+++ b/test/com/amplitude/api/BaseTest.java
@@ -91,7 +91,8 @@ public class BaseTest {
         // Clear the database helper for each test. Better to have isolation.
         // See https://github.com/robolectric/robolectric/issues/569
         // and https://github.com/robolectric/robolectric/issues/1622
-        DatabaseHelper.instance = null;
+        Amplitude.instances.clear();
+        DatabaseHelper.instances.clear();
 
         if (withServer) {
             server = new MockWebServer();
@@ -125,7 +126,8 @@ public class BaseTest {
             server.shutdown();
         }
 
-        DatabaseHelper.instance = null;
+        Amplitude.instances.clear();
+        DatabaseHelper.instances.clear();
     }
 
     public RecordedRequest runRequest(AmplitudeClient amplitude) {

--- a/test/com/amplitude/api/PinningTest.java
+++ b/test/com/amplitude/api/PinningTest.java
@@ -81,7 +81,7 @@ public class PinningTest extends BaseTest {
               + "XCBeVmjEX3kh4bkRPHJ5vyASNXUkF3nwVAe4cwOoLHN8o=");
 
         public InvalidPinnedAmplitudeClient() {
-            super();
+            super(Constants.DEFAULT_INSTANCE);
             super.getPinnedCertSslSocketFactory(INVALID_SSL_CONTEXT);
         }
     }

--- a/test/com/amplitude/api/PinningTest.java
+++ b/test/com/amplitude/api/PinningTest.java
@@ -21,6 +21,7 @@ public class PinningTest extends BaseTest {
     @Before
     public void setUp() throws Exception {
         super.setUp(false);
+        PinnedAmplitudeClient.instances.clear();
         // need to set clock > 0 so that logThread posts in order
         SystemClock.setCurrentTimeMillis(1000);
     }
@@ -28,6 +29,7 @@ public class PinningTest extends BaseTest {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
+        PinnedAmplitudeClient.instances.clear();
     }
 
     @Test


### PR DESCRIPTION
Feature parity with our iOS / JS SDKs.

Instead of 1 static instance of the AmplitudeClient, we have the Amplitude parent class maintain a map from instance name to AmplitudeClient. 

New calling convention: `Amplitude.getInstance("app name").<function>`
Existing calls to `Amplitude.getInstance()` will get mapped to the default instance (we catch null instance names and substitute with "$default_instance"`.
Instance names are case insensitive by design choice

Need to add an instance map in 3 places: Amplitude parent class, DatabaseHelper class (each instance needs its own separate database file, the default instance keeps the existing database file so we don't need any migration code), PinnedAmplitudeClient 