### PR TITLE
Set user id new session

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1501,32 +1501,18 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient setUserId(final String userId) {
-        if (!contextAndApiKeySet("setUserId()")) {
-            return this;
-        }
-
-        final AmplitudeClient client = this;
-        runOnLogThread(new Runnable() {
-            @Override
-            public void run() {
-                if (Utils.isEmptyString(client.apiKey)) {  // in case initialization failed
-                    return;
-                }
-                client.userId = userId;
-                dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
-            }
-        });
-        return this;
+        return setUserId(userId, false);
     }
 
     /**
-     * Sets the user id (can be null). Ends the session for the previous user and starts a new
+     * Sets the user id (can be null).
+     * If startNewSession is true, ends the session for the previous user and starts a new
      * session for the new user id.
      *
      * @param userId the user id
      * @return the AmplitudeClient
      */
-    public AmplitudeClient setUserIdAndStartNewSession(final String userId) {
+    public AmplitudeClient setUserId(final String userId, final boolean startNewSession) {
         if (!contextAndApiKeySet("setUserId()")) {
             return this;
         }
@@ -1540,7 +1526,7 @@ public class AmplitudeClient {
                 }
 
                 // end previous session
-                if (trackingSessionEvents) {
+                if (startNewSession && trackingSessionEvents) {
                     sendSessionEvent(END_SESSION_EVENT);
                 }
 
@@ -1548,11 +1534,13 @@ public class AmplitudeClient {
                 dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
 
                 // start new session
-                long timestamp = getCurrentTimeMillis();
-                setSessionId(timestamp);
-                refreshSessionTime(timestamp);
-                if (trackingSessionEvents) {
-                    sendSessionEvent(START_SESSION_EVENT);
+                if (startNewSession) {
+                    long timestamp = getCurrentTimeMillis();
+                    setSessionId(timestamp);
+                    refreshSessionTime(timestamp);
+                    if (trackingSessionEvents) {
+                        sendSessionEvent(START_SESSION_EVENT);
+                    }
                 }
             }
         });

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1535,25 +1535,25 @@ public class AmplitudeClient {
         runOnLogThread(new Runnable() {
             @Override
             public void run() {
-            if (Utils.isEmptyString(client.apiKey)) {  // in case initialization failed
-                return;
-            }
+                if (Utils.isEmptyString(client.apiKey)) {  // in case initialization failed
+                    return;
+                }
 
-            // end previous session
-            if (trackingSessionEvents) {
-                sendSessionEvent(END_SESSION_EVENT);
-            }
+                // end previous session
+                if (trackingSessionEvents) {
+                    sendSessionEvent(END_SESSION_EVENT);
+                }
 
-            client.userId = userId;
-            dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
+                client.userId = userId;
+                dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
 
-            // start new session
-            long timestamp = getCurrentTimeMillis();
-            setSessionId(timestamp);
-            refreshSessionTime(timestamp);
-            if (trackingSessionEvents) {
-                sendSessionEvent(START_SESSION_EVENT);
-            }
+                // start new session
+                long timestamp = getCurrentTimeMillis();
+                setSessionId(timestamp);
+                refreshSessionTime(timestamp);
+                if (trackingSessionEvents) {
+                    sendSessionEvent(START_SESSION_EVENT);
+                }
             }
         });
         return this;

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1520,6 +1520,46 @@ public class AmplitudeClient {
     }
 
     /**
+     * Sets the user id (can be null). Ends the session for the previous user and starts a new
+     * session for the new user id.
+     *
+     * @param userId the user id
+     * @return the AmplitudeClient
+     */
+    public AmplitudeClient setUserIdAndStartNewSession(final String userId) {
+        if (!contextAndApiKeySet("setUserId()")) {
+            return this;
+        }
+
+        final AmplitudeClient client = this;
+        runOnLogThread(new Runnable() {
+            @Override
+            public void run() {
+            if (Utils.isEmptyString(client.apiKey)) {  // in case initialization failed
+                return;
+            }
+
+            // end previous session
+            if (trackingSessionEvents) {
+                sendSessionEvent(END_SESSION_EVENT);
+            }
+
+            client.userId = userId;
+            dbHelper.insertOrReplaceKeyValue(USER_ID_KEY, userId);
+
+            // start new session
+            long timestamp = getCurrentTimeMillis();
+            setSessionId(timestamp);
+            refreshSessionTime(timestamp);
+            if (trackingSessionEvents) {
+                sendSessionEvent(START_SESSION_EVENT);
+            }
+            }
+        });
+        return this;
+    }
+
+    /**
      * Sets a custom device id. <b>Note: only do this if you know what you are doing!</b>
      *
      * @param deviceId the device id

--- a/test/com/amplitude/api/SessionTest.java
+++ b/test/com/amplitude/api/SessionTest.java
@@ -1005,7 +1005,7 @@ public class SessionTest extends BaseTest {
         assertEquals(getUnsentEventCount(), 2);
 
         // set user id and validate session ended and new session started
-        amplitude.setUserIdAndStartNewSession("test_new_user");
+        amplitude.setUserId("test_new_user", true);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
 
         // total of 4 events, start session, test event, end session, start session


### PR DESCRIPTION
Expose a public `setUserIdAndStartNewSession` method that is basically https://github.com/amplitude/Amplitude-Android/blob/master/src/com/amplitude/api/AmplitudeClient.java#L1108-L1120 and sets the userId between sending the start and end session events.