### PR TITLE
lower event upload max batch size to 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Lowering event upload max batch size from 100 to 50. This should help to avoid out of memory issues on Android devices with low memory.
+
 ## 2.18.0 (April 19, 2018)
 
 * Added a `setUserId` method with optional boolean argument `startNewSession`, which when `true` starts a new session after changing the userId.

--- a/src/com/amplitude/api/Constants.java
+++ b/src/com/amplitude/api/Constants.java
@@ -18,7 +18,7 @@ public class Constants {
     public static final String DEFAULT_INSTANCE = "$default_instance";
 
     public static final int EVENT_UPLOAD_THRESHOLD = 30;
-    public static final int EVENT_UPLOAD_MAX_BATCH_SIZE = 100;
+    public static final int EVENT_UPLOAD_MAX_BATCH_SIZE = 50;
     public static final int EVENT_MAX_COUNT = 1000;
     public static final int EVENT_REMOVE_BATCH_SIZE = 20;
     public static final long EVENT_UPLOAD_PERIOD_MILLIS = 30 * 1000; // 30s


### PR DESCRIPTION
If an event upload succeeds, we then try to upload any remaining unsent events, in batches of 100. Depending on how big the event payloads are and the amount of memory on the device, this could cause an OOM crash. Decreasing the max batch size to 50 should be safe.