### PR TITLE
catch security exceptions when fetching adid

### DIFF
--- a/src/com/amplitude/api/DeviceInfo.java
+++ b/src/com/amplitude/api/DeviceInfo.java
@@ -224,6 +224,8 @@ public class DeviceInfo {
                 AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found!");
             } catch (InvocationTargetException e) {
                 AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+            } catch (SecurityException e) {
+                AmplitudeLog.getLogger().w(TAG, "Please update Google Play Services version");
             } catch (Exception e) {
                 AmplitudeLog.getLogger().e(TAG, "Encountered an error connecting to Google Play Services", e);
             }


### PR DESCRIPTION
Support ticket reporting this crash:
```
22836-23611/? W/AdvertisingIdClient: Error while reading from SharedPreferences 
java.lang.SecurityException: MODE_WORLD_READABLE no longer supported 
at android.app.ContextImpl.checkMode(ContextImpl.java:2420) 
at android.app.ContextImpl.getSharedPreferences(ContextImpl.java:382) 
at android.app.ContextImpl.getSharedPreferences(ContextImpl.java:372) 
at com.google.android.gms.ads.identifier.AdvertisingIdClient.getAdvertisingIdInfo(Unknown Source:12) 
at java.lang.reflect.Method.invoke(Native Method) 
at com.amplitude.api.DeviceInfo$CachedInfo.getAndCacheGoogleAdvertisingId(DeviceInfo.java:214) 
at com.amplitude.api.DeviceInfo$CachedInfo.getAdvertisingId(DeviceInfo.java:195) 
at com.amplitude.api.DeviceInfo$CachedInfo.<init>(DeviceInfo.java:56) 
at com.amplitude.api.DeviceInfo$CachedInfo.<init>(DeviceInfo.java:41) 
at com.amplitude.api.DeviceInfo.getCachedInfo(DeviceInfo.java:268) 
at com.amplitude.api.DeviceInfo.prefetch(DeviceInfo.java:274) 
at com.amplitude.api.AmplitudeClient.initializeDeviceInfo(AmplitudeClient.java:325) 
at com.amplitude.api.AmplitudeClient.access$000(AmplitudeClient.java:39) 
at com.amplitude.api.AmplitudeClient$1.run(AmplitudeClient.java:262) 
at android.os.Handler.handleCallback(Handler.java:790) 
at android.os.Handler.dispatchMessage(Handler.java:99) 
at android.os.Looper.loop(Looper.java:164) 
at android.os.HandlerThread.run(HandlerThread.java:65)
```

I investigated a little bit. We're calling `com.google.android.gms.ads.identifier.AdvertisingIdClient.getAdvertisingIdInfo` to fetch the ADID, and it looks like that attempts to pull SharedPrefs with mode `MODE_WORLD_READABLE`. That mode has been deprecated since Android M due to a security vulnerability, and now in Android N it actually throws a SecurityException [link here](https://stackoverflow.com/questions/39121052/java-lang-securityexception-mode-world-readable-no-longer-supported)

The issue is that the implementation of `getAdvertisingIdInfo` depends entirely on the Google Play Services library. The solution is to tell the customer / user of our SDK to update their version of GPS [link here](https://stackoverflow.com/questions/50476123/androidadvertisingid-exception-on-android-p). Unfortunately I think the only thing we can do in our SDK is just to catch `SecurityExceptions` when attempting to fetch the ADID.