### PR TITLE
Lower priority of WorkerThread

### DIFF
--- a/src/com/amplitude/api/WorkerThread.java
+++ b/src/com/amplitude/api/WorkerThread.java
@@ -2,11 +2,12 @@ package com.amplitude.api;
 
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Process;
 
 public class WorkerThread extends HandlerThread {
-	
+
 	public WorkerThread(String name) {
-		super(name);
+		super(name, Process.THREAD_PRIORITY_BACKGROUND);
 	}
 
 	private Handler handler;
@@ -14,7 +15,7 @@ public class WorkerThread extends HandlerThread {
 	Handler getHandler() {
 		return handler;
 	}
-	
+
 	void post(Runnable r) {
 		waitForInitialization();
 		handler.post(r);


### PR DESCRIPTION
I've investigated our apps performance using `systrace` and I noticed that two threads where getting a lot of CPU time. Turns out `logThread` and `httpThread` (the two internal worker threads) are running with a higher thread priority than recommended for background threads:

```
{comm: "logThread",
 tid: 20386,
 prio: 120,
 stateWhenDescheduled: "D"}
```

Since `WorkerThread` is used to perform background work for Amplitude it should run with a background thread priority. 
This way it won’t fight with the applications main thread for CPU scheduling time so much (see https://developer.android.com/reference/android/os/Process#THREAD_PRIORITY_BACKGROUND for further information).