### PR TITLE
Allow injection of custom Network Client

### DIFF
--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1434,8 +1434,7 @@ public class AmplitudeClient {
         identify(identify);
     }
 
-
-    public void NetworkClient(NetworkClient networkClient) {
+    public void setNetworkClient(NetworkClient networkClient) {
         this.networkClient = networkClient;
     }
 
@@ -1936,7 +1935,7 @@ public class AmplitudeClient {
                 Constants.API_VERSION,
                 apiKey,
                 events,
-                getCurrentTimeMillis(),
+                timestampString,
                 checksumString,
                 url);
 

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -9,7 +9,6 @@ import android.os.Build;
 import android.util.Pair;
 import com.amplitude.security.MD5;
 import okhttp3.OkHttpClient;
-import okhttp3.Response;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1943,7 +1942,7 @@ public class AmplitudeClient {
 
         try {
             Response response = this.networkClient.uploadEvents(eventUploadRequest, client);
-            String stringResponse = response.body().string();
+            String stringResponse = response.getBody();
             if (stringResponse.equals("success")) {
                 uploadSuccess = true;
                 logThread.post(new Runnable() {
@@ -1973,7 +1972,7 @@ public class AmplitudeClient {
             } else if (stringResponse.equals("request_db_write_failed")) {
                 logger.w(TAG,
                         "Couldn't write to request database on server, will attempt to reupload later");
-            } else if (response.code() == 413) {
+            } else if (response.getCode() == 413) {
 
                 // If blocked by one massive event, drop it
                 if (backoffUpload && backoffUploadBatchSize == 1) {

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -17,7 +17,6 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
-import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -157,6 +156,8 @@ public class AmplitudeClient {
     private boolean trackingSessionEvents = false;
     private boolean inForeground = false;
     private boolean flushEventsOnClose = true;
+
+    private NetworkClient networkClient;
 
     private AtomicBoolean updateScheduled = new AtomicBoolean(false);
     /**
@@ -1440,6 +1441,11 @@ public class AmplitudeClient {
             }
         }
         identify(identify);
+    }
+
+
+    public void setAmpNetworkClient(NetworkClient networkClient) {
+        this.networkClient = networkClient;
     }
 
     /**

--- a/src/com/amplitude/api/DefaultNetworkClient.java
+++ b/src/com/amplitude/api/DefaultNetworkClient.java
@@ -1,0 +1,33 @@
+package com.amplitude.api;
+
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+public class DefaultNetworkClient implements NetworkClient {
+
+    @Override
+    public Response uploadEvents(EventUploadRequest eventUploadRequest, OkHttpClient client) throws IOException {
+
+        String apiVersionString = "" + eventUploadRequest.getApiVersion();
+        String timestampString = "" + eventUploadRequest.getUploadTime();
+
+        FormBody body = new FormBody.Builder()
+                .add("v", apiVersionString)
+                .add("client", eventUploadRequest.getApiKey())
+                .add("e", eventUploadRequest.getEvents())
+                .add("upload_time", timestampString)
+                .add("checksum", eventUploadRequest.getChecksum())
+                .build();
+
+        Request request = new Request.Builder()
+                .url(eventUploadRequest.getUrl())
+                .post(body)
+                .build();
+
+        return client.newCall(request).execute();
+    }
+}

--- a/src/com/amplitude/api/DefaultNetworkClient.java
+++ b/src/com/amplitude/api/DefaultNetworkClient.java
@@ -3,7 +3,6 @@ package com.amplitude.api;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
 
 import java.io.IOException;
 
@@ -28,6 +27,7 @@ public class DefaultNetworkClient implements NetworkClient {
                 .post(body)
                 .build();
 
-        return client.newCall(request).execute();
+        okhttp3.Response response = client.newCall(request).execute();
+        return new Response(response.code(), response.body() == null ? "" : response.body().string());
     }
 }

--- a/src/com/amplitude/api/DefaultNetworkClient.java
+++ b/src/com/amplitude/api/DefaultNetworkClient.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class DefaultNetworkClient implements NetworkClient {
 
     @Override
-    public Response uploadEvents(EventUploadRequest eventUploadRequest, OkHttpClient client) throws IOException {
+    public Response uploadEvents(EventUploadRequest eventUploadRequest, OkHttpClient client) throws IOException, IllegalArgumentException {
 
         String apiVersionString = "" + eventUploadRequest.getApiVersion();
         String timestampString = "" + eventUploadRequest.getUploadTime();

--- a/src/com/amplitude/api/EventUploadRequest.java
+++ b/src/com/amplitude/api/EventUploadRequest.java
@@ -5,11 +5,11 @@ public class EventUploadRequest {
     final private int apiVersion;
     final private String apiKey;
     final private String events;
-    final private long uploadTime;
+    final private String uploadTime;
     final private String checksum;
     final private String url;
 
-    public EventUploadRequest(int apiVersion, String apiKey, String events, long uploadTime, String checksum, String url) {
+    public EventUploadRequest(int apiVersion, String apiKey, String events, String uploadTime, String checksum, String url) {
         this.apiVersion = apiVersion;
         this.apiKey = apiKey;
         this.events = events;
@@ -30,7 +30,7 @@ public class EventUploadRequest {
         return events;
     }
 
-    public long getUploadTime() {
+    public String getUploadTime() {
         return uploadTime;
     }
 

--- a/src/com/amplitude/api/EventUploadRequest.java
+++ b/src/com/amplitude/api/EventUploadRequest.java
@@ -1,0 +1,6 @@
+package com.amplitude.api;
+
+public interface EventUploadRequest {
+
+
+}

--- a/src/com/amplitude/api/EventUploadRequest.java
+++ b/src/com/amplitude/api/EventUploadRequest.java
@@ -1,6 +1,44 @@
 package com.amplitude.api;
 
-public interface EventUploadRequest {
+public class EventUploadRequest {
 
+    final private int apiVersion;
+    final private String apiKey;
+    final private String events;
+    final private long uploadTime;
+    final private String checksum;
+    final private String url;
 
+    public EventUploadRequest(int apiVersion, String apiKey, String events, long uploadTime, String checksum, String url) {
+        this.apiVersion = apiVersion;
+        this.apiKey = apiKey;
+        this.events = events;
+        this.uploadTime = uploadTime;
+        this.checksum = checksum;
+        this.url = url;
+    }
+
+    public int getApiVersion() {
+        return apiVersion;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getEvents() {
+        return events;
+    }
+
+    public long getUploadTime() {
+        return uploadTime;
+    }
+
+    public String getChecksum() {
+        return checksum;
+    }
+
+    public String getUrl() {
+        return url;
+    }
 }

--- a/src/com/amplitude/api/NetworkClient.java
+++ b/src/com/amplitude/api/NetworkClient.java
@@ -1,7 +1,6 @@
 package com.amplitude.api;
 
 import okhttp3.OkHttpClient;
-import okhttp3.Response;
 
 import java.io.IOException;
 

--- a/src/com/amplitude/api/NetworkClient.java
+++ b/src/com/amplitude/api/NetworkClient.java
@@ -1,0 +1,9 @@
+package com.amplitude.api;
+
+import okhttp3.Response;
+
+public interface NetworkClient {
+
+    Response uploadEvents();
+
+}

--- a/src/com/amplitude/api/NetworkClient.java
+++ b/src/com/amplitude/api/NetworkClient.java
@@ -1,9 +1,12 @@
 package com.amplitude.api;
 
+import okhttp3.OkHttpClient;
 import okhttp3.Response;
+
+import java.io.IOException;
 
 public interface NetworkClient {
 
-    Response uploadEvents();
+    Response uploadEvents(EventUploadRequest eventUploadRequest, OkHttpClient client) throws IOException, IllegalArgumentException;
 
 }

--- a/src/com/amplitude/api/Response.java
+++ b/src/com/amplitude/api/Response.java
@@ -1,0 +1,20 @@
+package com.amplitude.api;
+
+public class Response {
+
+    private final int code;
+    private final String body;
+
+    public Response(int code, String body) {
+        this.body = body;
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}


### PR DESCRIPTION
Hello! In the business I work we are required to only make connections using [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication), and, for that reason, we cannot use the SDK as is.

We have an internal proxy server that uses mTLS and talks to the “outside world”, but, in order to use that, we need to inject our custom network client that enforces mTLS and uses our custom request encoding.

What do you think about the current implementation? I made it in a way that it won’t break the existing API. The iOS version of this PR is [iOS #178](https://github.com/amplitude/Amplitude-iOS/pull/178).