### PR TITLE
Oncorruption logging

### DIFF
--- a/src/com/amplitude/api/Diagnostics.java
+++ b/src/com/amplitude/api/Diagnostics.java
@@ -115,6 +115,7 @@ public class Diagnostics {
                         event.put("timestamp", System.currentTimeMillis());
                         event.put("device_id", deviceId);
                         event.put("count", 1);
+                        event.put("library", String.format("amplitude-android/%s", Constants.VERSION));
 
                         if (exception != null) {
                             String stackTrace = Log.getStackTraceString(exception);

--- a/test/com/amplitude/api/DiagnosticsTest.java
+++ b/test/com/amplitude/api/DiagnosticsTest.java
@@ -129,14 +129,17 @@ public class DiagnosticsTest extends BaseTest {
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(0)).optString("error"), "test_error");
         assertTrue(logger.unsentErrors.get(logger.unsentErrorStrings.get(0)).optLong("timestamp") >= timestamp);
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(0)).optInt("count"), 1);
+        assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(0)).optString("library"), "amplitude-android/2.21.0");
         assertEquals(logger.unsentErrorStrings.get(1), "test_error1");
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(1)).optString("error"), "test_error1");
         assertTrue(logger.unsentErrors.get(logger.unsentErrorStrings.get(1)).optLong("timestamp") >= timestamp);
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(1)).optInt("count"), 1);
+        assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(1)).optString("library"), "amplitude-android/2.21.0");
         assertEquals(logger.unsentErrorStrings.get(2), "test_error2");
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(2)).optString("error"), "test_error2");
         assertTrue(logger.unsentErrors.get(logger.unsentErrorStrings.get(2)).optLong("timestamp") >= timestamp);
         assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(2)).optInt("count"), 1);
+        assertEquals(logger.unsentErrors.get(logger.unsentErrorStrings.get(2)).optString("library"), "amplitude-android/2.21.0");
 
         // test truncation
         logger.setDiagnosticEventMaxCount(7);


### PR DESCRIPTION
1. Added a custom onCorruption handler. Most of the code is from Android's `DefaultDatabaseErrorHandler`, I just added a call to Diagnostic logger to log an error with the current stack trace
2. I tried to do something fancy where I add a callback function to the corruption handler so it can also try to re-insert the metadata in the onCorruption method, but AFAIK you can't open a new database instance from inside the `DatabaseErrorHandler` class
3. Added some more metrics to the diagnostics logger (free / total / available heap, and free disk space)

Unfortunately was not able to trigger the onCorruption handler in any of the unit tests. For some reason the corrupted files trigger a `SqliteException: Cannot prepare statement, base error code: 26`, instead of `SQLiteDatabaseCorruptException` which triggers the onCorruption path