### PR TITLE
make start new session if needed public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Make `startNewSessionIfNeeded` a public method. Only call this if you know what you are doing. This may trigger a new session to start.
+
 ## 2.22.1 (March 21, 2019)
 
 * Store deviceId in SharedPreferences as backup in case SQLite database fails or becomes corrupted.

--- a/src/com/amplitude/api/AmplitudeClient.java
+++ b/src/com/amplitude/api/AmplitudeClient.java
@@ -1170,12 +1170,12 @@ public class AmplitudeClient {
     }
 
     /**
-     * Internal method to start a new session if needed.
+     * Public method to start a new session if needed.
      *
      * @param timestamp the timestamp
      * @return whether or not a new session was started
      */
-    boolean startNewSessionIfNeeded(long timestamp) {
+    public boolean startNewSessionIfNeeded(long timestamp) {
         if (inSession()) {
 
             if (isWithinMinTimeBetweenSessions(timestamp)) {


### PR DESCRIPTION
Customer request to make `startNewSessionIfNeeded` public: https://github.com/amplitude/Amplitude-iOS/issues/180

Tested calling the method in Android Demo

This is the Android version of: https://github.com/amplitude/Amplitude-iOS/pull/189