### PR TITLE
Able to track `api_level` as a device property

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -991,6 +991,9 @@ public class AmplitudeClient {
             if (appliedTrackingOptions.shouldTrackOsVersion()) {
                 event.put("os_version", replaceWithJSONNull(deviceInfo.getOsVersion()));
             }
+            if (appliedTrackingOptions.shouldTrackApiLevel()) {
+                event.put("api_level", replaceWithJSONNull(Build.VERSION.SDK_INT));
+            }
             if (appliedTrackingOptions.shouldTrackDeviceBrand()) {
                 event.put("device_brand", replaceWithJSONNull(deviceInfo.getBrand()));
             }

--- a/src/main/java/com/amplitude/api/Constants.java
+++ b/src/main/java/com/amplitude/api/Constants.java
@@ -69,6 +69,7 @@ public class Constants {
     public static final String AMP_TRACKING_OPTION_LAT_LNG = "lat_lng";
     public static final String AMP_TRACKING_OPTION_OS_NAME = "os_name";
     public static final String AMP_TRACKING_OPTION_OS_VERSION = "os_version";
+    public static final String AMP_TRACKING_OPTION_API_LEVEL = "api_level";
     public static final String AMP_TRACKING_OPTION_PLATFORM = "platform";
     public static final String AMP_TRACKING_OPTION_REGION = "region";
     public static final String AMP_TRACKING_OPTION_VERSION_NAME = "version_name";

--- a/src/main/java/com/amplitude/api/TrackingOptions.java
+++ b/src/main/java/com/amplitude/api/TrackingOptions.java
@@ -144,6 +144,15 @@ public class TrackingOptions {
         return shouldTrackField(Constants.AMP_TRACKING_OPTION_OS_VERSION);
     }
 
+    public TrackingOptions disableApiLevel() {
+        disableTrackingField(Constants.AMP_TRACKING_OPTION_API_LEVEL);
+        return this;
+    }
+
+    boolean shouldTrackApiLevel() {
+        return shouldTrackField(Constants.AMP_TRACKING_OPTION_API_LEVEL);
+    }
+
     public TrackingOptions disablePlatform() {
         disableTrackingField(Constants.AMP_TRACKING_OPTION_PLATFORM);
         return this;

--- a/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -75,6 +75,9 @@ public class AmplitudePlugin {
         if (trackingOptionsDict.optBoolean("disableOSVersion", false)) {
             trackingOptions.disableOsVersion();
         }
+        if (trackingOptionsDict.optBoolean("disableApiLevel", false)) {
+            trackingOptions.disableApiLevel();
+        }
         if (trackingOptionsDict.optBoolean("disablePlatform", false)) {
             trackingOptions.disablePlatform();
         }


### PR DESCRIPTION
Tested: events went through, not affected.