### PR TITLE
Fix - unable to disable location listening at the beginning

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -270,8 +270,7 @@ public class AmplitudeClient {
                         AmplitudeClient.upgradeSharedPrefsToDB(context);
                     }
                     httpClient = new OkHttpClient();
-                    deviceInfo = new DeviceInfo(context);
-                    deviceInfo.setLocationListening(this.locationListening);
+                    deviceInfo = new DeviceInfo(context, this.locationListening);
                     deviceId = initializeDeviceId();
                     deviceInfo.prefetch();
 
@@ -400,6 +399,9 @@ public class AmplitudeClient {
      */
     public AmplitudeClient enableLocationListening() {
         this.locationListening = true;
+        if (this.deviceInfo != null) {
+            this.deviceInfo.setLocationListening(true);
+        }
         return this;
     }
 
@@ -413,6 +415,9 @@ public class AmplitudeClient {
      */
     public AmplitudeClient disableLocationListening() {
         this.locationListening = false;
+        if (this.deviceInfo != null) {
+            this.deviceInfo.setLocationListening(false);
+        }
         return this;
     }
 

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -125,6 +125,7 @@ public class AmplitudeClient {
     TrackingOptions appliedTrackingOptions = TrackingOptions.copyOf(inputTrackingOptions);
     JSONObject apiPropertiesTrackingOptions = appliedTrackingOptions.getApiPropertiesTrackingOptions();
     private boolean coppaControlEnabled = false;
+    private boolean locationListening = true;
 
     /**
      * The device's Platform value.
@@ -270,6 +271,7 @@ public class AmplitudeClient {
                     }
                     httpClient = new OkHttpClient();
                     deviceInfo = new DeviceInfo(context);
+                    deviceInfo.setLocationListening(this.locationListening);
                     deviceId = initializeDeviceId();
                     deviceInfo.prefetch();
 
@@ -392,19 +394,12 @@ public class AmplitudeClient {
      * Enable location listening in the SDK. This will add the user's current lat/lon coordinates
      * to every event logged.
      *
+     * This function should be called before SDK initialization, e.g. {@link #initialize(Context, String)}.
+     *
      * @return the AmplitudeClient
      */
     public AmplitudeClient enableLocationListening() {
-        runOnLogThread(new Runnable() {
-            @Override
-            public void run() {
-                if (deviceInfo == null) {
-		    throw new IllegalStateException(
-		            "Must initialize before acting on location listening.");
-                }
-                deviceInfo.setLocationListening(true);
-            }
-        });
+        this.locationListening = true;
         return this;
     }
 
@@ -412,19 +407,12 @@ public class AmplitudeClient {
      * Disable location listening in the SDK. This will stop the sending of the user's current
      * lat/lon coordinates.
      *
+     * This function should be called before SDK initialization, e.g. {@link #initialize(Context, String)}.
+     *
      * @return the AmplitudeClient
      */
     public AmplitudeClient disableLocationListening() {
-        runOnLogThread(new Runnable() {
-            @Override
-            public void run() {
-                if (deviceInfo == null) {
-		    throw new IllegalStateException(
-		            "Must initialize before acting on location listening.");
-                }
-                deviceInfo.setLocationListening(false);
-            }
-        });
+        this.locationListening = false;
         return this;
     }
 

--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -3,7 +3,6 @@ package com.amplitude.api;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.location.Address;
 import android.location.Geocoder;
@@ -264,8 +263,9 @@ public class DeviceInfo {
         }
     }
 
-    public DeviceInfo(Context context) {
+    public DeviceInfo(Context context, boolean locationListening) {
         this.context = context;
+        this.locationListening = locationListening;
     }
 
     private CachedInfo getCachedInfo() {

--- a/src/test/java/com/amplitude/api/DeviceInfoTest.java
+++ b/src/test/java/com/amplitude/api/DeviceInfoTest.java
@@ -3,9 +3,7 @@ package com.amplitude.api;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.location.Geocoder;
 import android.location.Location;
-import android.location.LocationManager;
 import android.os.Build;
 import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
@@ -29,11 +27,8 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.ShadowLocationManager;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowTelephonyManager;
-import org.robolectric.shadows.maps.ShadowGeocoder;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.util.Locale;
@@ -90,7 +85,7 @@ public class DeviceInfoTest extends BaseTest {
         ShadowTelephonyManager manager = Shadows.shadowOf((TelephonyManager) context
                 .getSystemService(Context.TELEPHONY_SERVICE));
         manager.setNetworkOperatorName(TEST_CARRIER);
-        deviceInfo = new DeviceInfo(context);
+        deviceInfo = new DeviceInfo(context, true);
     }
 
     @After
@@ -134,7 +129,7 @@ public class DeviceInfoTest extends BaseTest {
                 .getSystemService(Context.TELEPHONY_SERVICE));
         manager.setNetworkCountryIso(TEST_NETWORK_COUNTRY);
 
-        DeviceInfo deviceInfo = new DeviceInfo(context);
+        DeviceInfo deviceInfo = new DeviceInfo(context, true);
         assertEquals(TEST_NETWORK_COUNTRY, deviceInfo.getCountry());
     }
 
@@ -184,7 +179,7 @@ public class DeviceInfoTest extends BaseTest {
         } catch (Exception e) {
             fail(e.toString());
         }
-        DeviceInfo deviceInfo = new DeviceInfo(context);
+        DeviceInfo deviceInfo = new DeviceInfo(context, true);
 
         // still get advertisingId even if limit ad tracking disabled
         assertEquals(advertisingId, deviceInfo.getAdvertisingId());
@@ -201,7 +196,7 @@ public class DeviceInfoTest extends BaseTest {
         Secure.putInt(cr, "limit_ad_tracking", 1);
         Secure.putString(cr, "advertising_id", advertisingId);
 
-        DeviceInfo deviceInfo = new DeviceInfo(context);
+        DeviceInfo deviceInfo = new DeviceInfo(context, true);
 
         // still get advertisingID even if limit ad tracking enabled
         assertEquals(advertisingId, deviceInfo.getAdvertisingId());
@@ -211,7 +206,7 @@ public class DeviceInfoTest extends BaseTest {
     @Test
     public void testGPSDisabled() {
         // GPS not enabled
-        DeviceInfo deviceInfo = new DeviceInfo(context);
+        DeviceInfo deviceInfo = new DeviceInfo(context, true);
         assertFalse(deviceInfo.isGooglePlayServicesEnabled());
 
         // GPS bundled but not enabled, GooglePlayUtils.isAvailable returns non-0 value
@@ -252,7 +247,7 @@ public class DeviceInfoTest extends BaseTest {
 
     @Test
     public void testNoLocation() {
-        DeviceInfo deviceInfo = new DeviceInfo(context);
+        DeviceInfo deviceInfo = new DeviceInfo(context, true);
         Location recent = deviceInfo.getMostRecentLocation();
         assertNull(recent);
     }


### PR DESCRIPTION
Once location is cached, you won't be able to disable location listening at all. However, disabling location listening will result crash if it's called before initialization.
#240 