### PR TITLE
Expose event upload millis API for use in Unity

### DIFF
--- a/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -156,6 +156,10 @@ public class AmplitudePlugin {
         Amplitude.getInstance(instanceName).setMinTimeBetweenSessionsMillis(minTimeBetweenSessionsMillis);
     }
 
+    public static void setEventUploadPeriodMillis(String instanceName, int eventUploadPeriodMillis) {
+        Amplitude.getInstance(instanceName).setEventUploadPeriodMillis(eventUploadPeriodMillis);
+    }
+
     public static void setUserProperties(String instanceName, String jsonProperties) {
         Amplitude.getInstance(instanceName).setUserProperties(ToJSONObject(jsonProperties));
     }


### PR DESCRIPTION
Note that the current Android AmplitudeClient API uses

```
public AmplitudeClient setEventUploadPeriodMillis(int eventUploadPeriodMillis) {
        this.eventUploadPeriodMillis = eventUploadPeriodMillis;
        return this;
    }
```