### PR TITLE
Master <- Main

### DIFF
--- a/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -156,6 +156,10 @@ public class AmplitudePlugin {
         Amplitude.getInstance(instanceName).setMinTimeBetweenSessionsMillis(minTimeBetweenSessionsMillis);
     }
 
+    public static void setEventUploadPeriodMillis(String instanceName, int eventUploadPeriodMillis) {
+        Amplitude.getInstance(instanceName).setEventUploadPeriodMillis(eventUploadPeriodMillis);
+    }
+
     public static void setUserProperties(String instanceName, String jsonProperties) {
         Amplitude.getInstance(instanceName).setUserProperties(ToJSONObject(jsonProperties));
     }


### PR DESCRIPTION
Recently, GitHub changed the name of the default `master` branch to `main`. I agree with GitHub's change in support of social justice. However, this change broke our Jenkins/Docker CI job, see [here](https://github.com/amplitude/deploy/blob/6c21781b2ea4292d34ea06b299709f60d7026c38/utils/sdk/android/release.sh#L68). 

This will allow us to build on Jenkins again for a [customer feature request](https://github.com/amplitude/unity-plugin/pull/58).