### PR TITLE
bug: add more error handling for cursor allocation exception

### DIFF
--- a/src/main/java/com/amplitude/api/DatabaseHelper.java
+++ b/src/main/java/com/amplitude/api/DatabaseHelper.java
@@ -541,7 +541,7 @@ class DatabaseHelper extends SQLiteOpenHelper {
      */
     private static void convertIfCursorWindowException(RuntimeException e) {
         String message = e.getMessage();
-        if (!Utils.isEmptyString(message) && message.startsWith("Cursor window allocation of")) {
+        if (!Utils.isEmptyString(message) && (message.startsWith("Cursor window allocation of") || message.startsWith("Could not allocate CursorWindow"))) {
             throw new CursorWindowAllocationException(message);
         } else {
             throw e;


### PR DESCRIPTION
Fixes #283 

The underlying android exception CursorWindowAllocationException was not correctly getting converted to our own implementation of that exception because its message string was formatted differently. This led to an unhandled RuntimeException being thrown. 

This PR also checks for the alternate formatting before converting the exception.