### PR TITLE
Appsetid support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,6 @@ dependencies {
     testImplementation 'com.google.android:support-v4:r6'
     testImplementation 'com.google.android.gms:play-services-ads:18.3.0'
     testImplementation 'com.google.android.gms:play-services-base:17.1.0'
-    testImplementation 'com.google.android.gms:play-services-appset:16.0.0-alpha1'
 
     testImplementation "junit:junit:4.12"
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     testImplementation 'com.google.android:support-v4:r6'
     testImplementation 'com.google.android.gms:play-services-ads:18.3.0'
     testImplementation 'com.google.android.gms:play-services-base:17.1.0'
+    testImplementation 'com.google.android.gms:play-services-appset:16.0.0-alpha1'
 
     testImplementation "junit:junit:4.12"
 

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -121,8 +121,7 @@ public class AmplitudeClient {
      */
     protected String deviceId;
     private boolean newDeviceIdPerInstall = false;
-    private boolean useAdvertisingIdForDeviceId = false;
-    private boolean useAppSetIdForDeviceId = false;
+    private DeviceIdType deviceIdType = null;
     protected boolean initialized = false;
     private boolean optOut = false;
     private boolean offline = false;
@@ -466,8 +465,7 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient useAdvertisingIdForDeviceId() {
-        this.useAdvertisingIdForDeviceId = true;
-        this.useAppSetIdForDeviceId = false;
+        deviceIdType = DeviceIdType.ADID;
         return this;
     }
 
@@ -477,8 +475,7 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient useAppSetIdForDeviceId() {
-        this.useAppSetIdForDeviceId = true;
-        this.useAdvertisingIdForDeviceId = false;
+        deviceIdType = DeviceIdType.APP_SET_ID;
         return this;
     }
 
@@ -2200,7 +2197,7 @@ public class AmplitudeClient {
             return deviceId;
         }
 
-        if (!newDeviceIdPerInstall && useAdvertisingIdForDeviceId && !deviceInfo.isLimitAdTrackingEnabled()) {
+        if (!newDeviceIdPerInstall && deviceIdType == DeviceIdType.ADID && !deviceInfo.isLimitAdTrackingEnabled()) {
             // Android ID is deprecated by Google.
             // We are required to use Advertising ID, and respect the advertising ID preference
 
@@ -2211,9 +2208,10 @@ public class AmplitudeClient {
             }
         }
 
-        if (useAppSetIdForDeviceId) {
+        if (deviceIdType == DeviceIdType.APP_SET_ID) {
             String appSetId = deviceInfo.getAppSetId();
             if (!(Utils.isEmptyString(appSetId) || invalidIds.contains(appSetId))) {
+                // Suffix with S for app set id so in future we can tell if device id is from app set id
                 String appSetDeviceId = appSetId + "S";
                 saveDeviceId(appSetDeviceId);
                 return appSetDeviceId;

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -1172,7 +1172,7 @@ public class AmplitudeClient {
                 apiProperties.put("androidADID", deviceInfo.getAdvertisingId());
             }
             if (appliedTrackingOptions.shouldTrackAppSetId() && deviceInfo.getAppSetId() != null) {
-                apiProperties.put("androidAppSetId", deviceInfo.getAppSetId());
+                apiProperties.put("android_app_set_id", deviceInfo.getAppSetId());
             }
             apiProperties.put("limit_ad_tracking", deviceInfo.isLimitAdTrackingEnabled());
             apiProperties.put("gps_enabled", deviceInfo.isGooglePlayServicesEnabled());

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -465,7 +465,7 @@ public class AmplitudeClient {
      * @return the AmplitudeClient
      */
     public AmplitudeClient useAdvertisingIdForDeviceId() {
-        deviceIdType = DeviceIdType.ADID;
+        deviceIdType = DeviceIdType.ADVERTISING_ID;
         return this;
     }
 
@@ -2197,7 +2197,7 @@ public class AmplitudeClient {
             return deviceId;
         }
 
-        if (!newDeviceIdPerInstall && deviceIdType == DeviceIdType.ADID && !deviceInfo.isLimitAdTrackingEnabled()) {
+        if (!newDeviceIdPerInstall && deviceIdType == DeviceIdType.ADVERTISING_ID && !deviceInfo.isLimitAdTrackingEnabled()) {
             // Android ID is deprecated by Google.
             // We are required to use Advertising ID, and respect the advertising ID preference
 

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -2211,7 +2211,7 @@ public class AmplitudeClient {
             }
         }
 
-        if (useAppSetIdForDeviceId ) {
+        if (useAppSetIdForDeviceId) {
             String appSetId = deviceInfo.getAppSetId();
             if (!(Utils.isEmptyString(appSetId) || invalidIds.contains(appSetId))) {
                 String appSetDeviceId = appSetId + "S";

--- a/src/main/java/com/amplitude/api/Constants.java
+++ b/src/main/java/com/amplitude/api/Constants.java
@@ -63,6 +63,7 @@ public class Constants {
     public static final String AMP_REVENUE_RECEIPT_SIG = "$receiptSig";
 
     public static final String AMP_TRACKING_OPTION_ADID = "adid";
+    public static final String AMP_TRACKING_OPTION_APP_SET_ID = "app_set_id";
     public static final String AMP_TRACKING_OPTION_CARRIER = "carrier";
     public static final String AMP_TRACKING_OPTION_CITY = "city";
     public static final String AMP_TRACKING_OPTION_COUNTRY = "country";

--- a/src/main/java/com/amplitude/api/DeviceIdType.java
+++ b/src/main/java/com/amplitude/api/DeviceIdType.java
@@ -1,0 +1,5 @@
+package com.amplitude.api;
+
+enum DeviceIdType {
+    ADID, APP_SET_ID;
+}

--- a/src/main/java/com/amplitude/api/DeviceIdType.java
+++ b/src/main/java/com/amplitude/api/DeviceIdType.java
@@ -1,5 +1,5 @@
 package com.amplitude.api;
 
 enum DeviceIdType {
-    ADID, APP_SET_ID;
+    ADVERTISING_ID, APP_SET_ID;
 }

--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -216,9 +216,9 @@ public class DeviceInfo {
                 Method getId = appSetInfo.getClass().getMethod("getId");
                 appSetId = (String) getId.invoke(appSetInfo);
             } catch (ClassNotFoundException e) {
-                AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found!");
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found for app set id!");
             } catch (InvocationTargetException e) {
-                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available for app set id");
             } catch (Exception e) {
                 AmplitudeLog.getLogger().e(TAG, "Encountered an error connecting to Google Play Services for app set id", e);
             }
@@ -251,11 +251,11 @@ public class DeviceInfo {
                 Method getId = advertisingInfo.getClass().getMethod("getId");
                 advertisingId = (String) getId.invoke(advertisingInfo);
             } catch (ClassNotFoundException e) {
-                AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found!");
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found for advertising id!");
             } catch (InvocationTargetException e) {
-                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available for advertising id");
             } catch (Exception e) {
-                AmplitudeLog.getLogger().e(TAG, "Encountered an error connecting to Google Play Services", e);
+                AmplitudeLog.getLogger().e(TAG, "Encountered an error connecting to Google Play Services for advertising id", e);
             }
 
             return advertisingId;

--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -52,6 +52,7 @@ public class DeviceInfo {
         private String language;
         private boolean limitAdTrackingEnabled;
         private boolean gpsEnabled; // google play services
+        private String appSetId;
 
         private CachedInfo() {
             advertisingId = getAdvertisingId();
@@ -65,6 +66,7 @@ public class DeviceInfo {
             country = getCountry();
             language = getLanguage();
             gpsEnabled = checkGPSEnabled();
+            appSetId = getAppSetId();
         }
 
         /**
@@ -200,6 +202,30 @@ public class DeviceInfo {
             }
         }
 
+        private String getAppSetId() {
+            try {
+                Class AppSet = Class
+                        .forName("com.google.android.gms.appset.AppSet");
+                Method getClient = AppSet.getMethod("getClient", Context.class);
+                Object appSetClient = getClient.invoke(null, context);
+                Method getAppSetInfo = appSetClient.getClass().getMethod("getAppSetInfo");
+                Object taskWithAppSetInfo = getAppSetInfo.invoke(appSetClient);
+                Class Tasks = Class.forName("com.google.android.gms.tasks.Tasks");
+                Method await = Tasks.getMethod("await", Class.forName("com.google.android.gms.tasks.Task"));
+                Object appSetInfo = await.invoke(null, taskWithAppSetInfo);
+                Method getId = appSetInfo.getClass().getMethod("getId");
+                appSetId = (String) getId.invoke(appSetInfo);
+            } catch (ClassNotFoundException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services SDK not found!");
+            } catch (InvocationTargetException e) {
+                AmplitudeLog.getLogger().w(TAG, "Google Play Services not available");
+            } catch (Exception e) {
+                AmplitudeLog.getLogger().e(TAG, "Encountered an error connecting to Google Play Services for app set id", e);
+            }
+
+            return appSetId;
+        }
+
         private String getAndCacheAmazonAdvertisingId() {
             ContentResolver cr = context.getContentResolver();
 
@@ -325,6 +351,10 @@ public class DeviceInfo {
 
     public boolean isLimitAdTrackingEnabled() {
         return getCachedInfo().limitAdTrackingEnabled;
+    }
+
+    public String getAppSetId() {
+        return getCachedInfo().appSetId;
     }
 
     public boolean isGooglePlayServicesEnabled() { return getCachedInfo().gpsEnabled; }

--- a/src/main/java/com/amplitude/api/TrackingOptions.java
+++ b/src/main/java/com/amplitude/api/TrackingOptions.java
@@ -36,6 +36,15 @@ public class TrackingOptions {
         return shouldTrackField(Constants.AMP_TRACKING_OPTION_ADID);
     }
 
+    public TrackingOptions disableAppSetId() {
+        disableTrackingField(Constants.AMP_TRACKING_OPTION_APP_SET_ID);
+        return this;
+    }
+
+    boolean shouldTrackAppSetId() {
+        return shouldTrackField(Constants.AMP_TRACKING_OPTION_APP_SET_ID);
+    }
+
     public TrackingOptions disableCarrier() {
         disableTrackingField(Constants.AMP_TRACKING_OPTION_CARRIER);
         return this;

--- a/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
+++ b/src/main/java/com/amplitude/unity/plugins/AmplitudePlugin.java
@@ -39,6 +39,9 @@ public class AmplitudePlugin {
         if (trackingOptionsDict.optBoolean("disableADID", false)) {
             trackingOptions.disableAdid();
         }
+        if (trackingOptionsDict.optBoolean("disableAppSetId", false)) {
+            trackingOptions.disableAppSetId();
+        }
         if (trackingOptionsDict.optBoolean("disableCarrier", false)) {
             trackingOptions.disableCarrier();
         }
@@ -138,6 +141,10 @@ public class AmplitudePlugin {
 
     public static void useAdvertisingIdForDeviceId(String instanceName) {
         Amplitude.getInstance(instanceName).useAdvertisingIdForDeviceId();
+    }
+
+    public static void useAppSetIdForDeviceId(String instanceName) {
+        Amplitude.getInstance(instanceName).useAppSetIdForDeviceId();
     }
 
     public static void setOffline(String instanceName, boolean offline) {

--- a/src/test/java/com/amplitude/api/TrackingOptionsTest.java
+++ b/src/test/java/com/amplitude/api/TrackingOptionsTest.java
@@ -75,18 +75,20 @@ public class TrackingOptionsTest extends BaseTest {
         assertFalse(options.shouldTrackAdid());
         assertFalse(options.shouldTrackCity());
         assertFalse(options.shouldTrackIpAddress());
+        assertFalse(options.shouldTrackLatLng());
     }
 
     @Test
     public void testMerging() {
         TrackingOptions options1 = TrackingOptions.forCoppaControl();
-        TrackingOptions options2 = new TrackingOptions().disableCountry().disableLanguage();
+        TrackingOptions options2 = new TrackingOptions().disableCountry().disableLanguage().disableAppSetId();
         options1.mergeIn(options2);
         assertFalse(options1.shouldTrackAdid());
         assertFalse(options1.shouldTrackCity());
         assertFalse(options1.shouldTrackIpAddress());
         assertFalse(options1.shouldTrackCountry());
         assertFalse(options1.shouldTrackLanguage());
+        assertFalse(options1.shouldTrackAppSetId());
     }
 
     @Test
@@ -95,14 +97,15 @@ public class TrackingOptionsTest extends BaseTest {
         assertFalse(options.shouldTrackAdid());
         assertFalse(options.shouldTrackCity());
         assertFalse(options.shouldTrackIpAddress());
+        assertFalse(options.shouldTrackLatLng());
     }
 
     @Test
     public void testEquals() {
         TrackingOptions options1 = new TrackingOptions();
-        options1.disableAdid().disableCarrier();
+        options1.disableAdid().disableCarrier().disableAppSetId();
         TrackingOptions options2 = new TrackingOptions();
-        options2.disableAdid().disableCarrier();
+        options2.disableAdid().disableCarrier().disableAppSetId();
         assertEquals(options1, options2);
     }
 }


### PR DESCRIPTION
Add app set id support

### Changes
add app set id get function (Use reflection, tested on emulator with no package installed and package installed, can get the app set id in later case)
support useAppSetIdForDeviceId (Use synchronous to align on the pattern as of today.)
add app set id in api properties
add app set id in tracking options
expose useAppSetIdForDeviceId and disableAppSetId in plugin

[Android doc](https://developer.android.com/training/articles/app-set-id#java)