### PR TITLE
fixed detecting device language

### DIFF
--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -4,11 +4,14 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.location.Address;
 import android.location.Geocoder;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Build;
+import android.os.LocaleList;
 import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
 
@@ -185,12 +188,26 @@ public class DeviceInfo {
             return null;
         }
 
+        private Locale getLocale() {
+            final Configuration configuration = Resources.getSystem().getConfiguration();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                final LocaleList localeList = configuration.getLocales();
+                if (localeList.isEmpty()) {
+                    return Locale.getDefault();
+                } else {
+                    return localeList.get(0);
+                }
+            } else {
+                return configuration.locale;
+            }
+        }
+
         private String getCountryFromLocale() {
-            return Locale.getDefault().getCountry();
+            return getLocale().getCountry();
         }
 
         private String getLanguage() {
-            return Locale.getDefault().getLanguage();
+            return getLocale().getLanguage();
         }
 
         private String getAdvertisingId() {

--- a/src/test/java/com/amplitude/api/DeviceInfoTest.java
+++ b/src/test/java/com/amplitude/api/DeviceInfoTest.java
@@ -3,8 +3,10 @@ package com.amplitude.api;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.location.Location;
 import android.os.Build;
+import android.os.LocaleList;
 import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
 
@@ -89,7 +91,7 @@ public class DeviceInfoTest extends BaseTest {
         ReflectionHelpers.setStaticField(Build.class, "MODEL", TEST_MODEL);
 
         Configuration c = context.getResources().getConfiguration();
-        Locale.setDefault(TEST_LOCALE);
+        Resources.getSystem().getConfiguration().setLocales(LocaleList.forLanguageTags(TEST_LANGUAGE));
 
         ShadowTelephonyManager manager = Shadows.shadowOf((TelephonyManager) context
                 .getSystemService(Context.TELEPHONY_SERVICE));

--- a/src/test/java/com/amplitude/api/DeviceInfoTest.java
+++ b/src/test/java/com/amplitude/api/DeviceInfoTest.java
@@ -91,7 +91,7 @@ public class DeviceInfoTest extends BaseTest {
         ReflectionHelpers.setStaticField(Build.class, "MODEL", TEST_MODEL);
 
         Configuration c = context.getResources().getConfiguration();
-        Resources.getSystem().getConfiguration().setLocales(LocaleList.forLanguageTags(TEST_LANGUAGE));
+        Resources.getSystem().getConfiguration().setLocales(LocaleList.forLanguageTags(TEST_LOCALE.toLanguageTag()));
 
         ShadowTelephonyManager manager = Shadows.shadowOf((TelephonyManager) context
                 .getSystemService(Context.TELEPHONY_SERVICE));


### PR DESCRIPTION
In case of changing the app language programmatically it also needs to call `Locale.setDefault()` because `Locale.getDefault()` is  used in many android SDK places. So it's better to use `Resources.getSystem().getConfiguration().getLocales() ` to detect the device language. 
