### PR TITLE
fix: App Crash due to SecurityException

### DIFF
--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -164,6 +164,8 @@ public class DeviceInfo {
                     // Bad lat / lon values can cause Geocoder to throw IllegalArgumentExceptions
                 } catch (IllegalStateException e) {
                     // sometimes the location manager is unavailable
+                } catch (SecurityException e) {
+                    // Customized Android System without Google Play Service Installed
                 }
             }
             return null;


### PR DESCRIPTION
Summary

1. Handle SecurityException thrown by calling Geocoder.getFromLocation()

Checklist
[X ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Java/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
Does your PR have a breaking change?: no