### PR TITLE
fix: mark connector package as required in pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,9 @@ uploadArchives {
 
         pom.whenConfigured { pom ->
             pom.dependencies*.optional = true
+            pom.dependencies.find { dep ->
+                dep.groupId == 'com.amplitude' && dep.artifactId == 'analytics-connector'
+            }.optional = false
         }
 
         repository(url: RELEASE_REPOSITORY_URL) {


### PR DESCRIPTION
Potential solution for #320 

Mark analytics-connector dependency as not optional (required) in pom