### PR TITLE
feat: add ingestion_metadata field

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -140,6 +140,12 @@ public class AmplitudeClient {
     private boolean locationListening = true;
     private EventExplorer eventExplorer;
     private Plan plan;
+
+    /**
+     * The ingestion metadata.
+     */
+    private IngestionMetadata ingestionMetadata;
+
     /**
      * Amplitude Server Zone
      */
@@ -1252,6 +1258,10 @@ public class AmplitudeClient {
 
             if (plan != null) {
                 event.put("plan", plan.toJSONObject());
+            }
+
+            if (ingestionMetadata != null) {
+                event.put("ingestion_metadata", ingestionMetadata.toJSONObject());
             }
 
             apiProperties = (apiProperties == null) ? new JSONObject() : apiProperties;
@@ -2488,6 +2498,16 @@ public class AmplitudeClient {
      */
     public AmplitudeClient setPlan(Plan plan) {
         this.plan = plan;
+        return this;
+    }
+
+    /**
+     * Set ingestion metadata information.
+     * @param ingestionMetadata IngestionMetadata object
+     * @return the AmplitudeClient
+     */
+    public AmplitudeClient setIngestionMetadata(IngestionMetadata ingestionMetadata) {
+        this.ingestionMetadata = ingestionMetadata;
         return this;
     }
 

--- a/src/main/java/com/amplitude/api/Constants.java
+++ b/src/main/java/com/amplitude/api/Constants.java
@@ -88,6 +88,6 @@ public class Constants {
     public static final String AMP_PLAN_VERSION = "version";
     public static final String AMP_PLAN_VERSION_ID = "versionId";
 
-    public static final String INGESTION_METADATA_SOURCE_NAME = "source_name";
-    public static final String INGESTION_METADATA_SOURCE_VERSION = "source_version";
+    public static final String AMP_INGESTION_METADATA_SOURCE_NAME = "source_name";
+    public static final String AMP_INGESTION_METADATA_SOURCE_VERSION = "source_version";
 }

--- a/src/main/java/com/amplitude/api/Constants.java
+++ b/src/main/java/com/amplitude/api/Constants.java
@@ -87,4 +87,7 @@ public class Constants {
     public static final String AMP_PLAN_SOURCE = "source";
     public static final String AMP_PLAN_VERSION = "version";
     public static final String AMP_PLAN_VERSION_ID = "versionId";
+
+    public static final String INGESTION_METADATA_SOURCE_NAME = "source_name";
+    public static final String INGESTION_METADATA_SOURCE_VERSION = "source_version";
 }

--- a/src/main/java/com/amplitude/api/IngestionMetadata.java
+++ b/src/main/java/com/amplitude/api/IngestionMetadata.java
@@ -42,10 +42,10 @@ public class IngestionMetadata {
         JSONObject jsonObject = new JSONObject();
         try {
             if (!Utils.isEmptyString(sourceName)) {
-                jsonObject.put(Constants.INGESTION_METADATA_SOURCE_NAME, sourceName);
+                jsonObject.put(Constants.AMP_INGESTION_METADATA_SOURCE_NAME, sourceName);
             }
             if (!Utils.isEmptyString(sourceVersion)) {
-                jsonObject.put(Constants.INGESTION_METADATA_SOURCE_VERSION, sourceVersion);
+                jsonObject.put(Constants.AMP_INGESTION_METADATA_SOURCE_VERSION, sourceVersion);
             }
         } catch (JSONException e) {
             AmplitudeLog.getLogger().e(TAG, "JSON Serialization of ingestion metadata object failed");

--- a/src/main/java/com/amplitude/api/IngestionMetadata.java
+++ b/src/main/java/com/amplitude/api/IngestionMetadata.java
@@ -1,0 +1,55 @@
+package com.amplitude.api;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class IngestionMetadata {
+    private static final String TAG = IngestionMetadata.class.getName();
+    /**
+     * The source name, e.g. "ampli"
+     */
+    private String sourceName;
+    /**
+     * The source version, e.g. "2.0.0"
+     */
+    private String sourceVersion;
+
+    /**
+     * Set the ingestion metadata source name information.
+     * @param sourceName source name for ingestion metadata
+     * @return the same IngestionMetadata object
+     */
+    public IngestionMetadata setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+        return this;
+    }
+
+    /**
+     * Set the ingestion metadata source version information.
+     * @param sourceVersion source version for ingestion metadata
+     * @return the same IngestionMetadata object
+     */
+    public IngestionMetadata setSourceVersion(String sourceVersion) {
+        this.sourceVersion = sourceVersion;
+        return this;
+    }
+
+    /**
+     * Get JSONObject of current ingestion metadata
+     * @return JSONObject including ingestion metadata information
+     */
+    protected JSONObject toJSONObject() {
+        JSONObject jsonObject = new JSONObject();
+        try {
+            if (!Utils.isEmptyString(sourceName)) {
+                jsonObject.put(Constants.INGESTION_METADATA_SOURCE_NAME, sourceName);
+            }
+            if (!Utils.isEmptyString(sourceVersion)) {
+                jsonObject.put(Constants.INGESTION_METADATA_SOURCE_VERSION, sourceVersion);
+            }
+        } catch (JSONException e) {
+            AmplitudeLog.getLogger().e(TAG, "JSON Serialization of ingestion metadata object failed");
+        }
+        return jsonObject;
+    }
+}

--- a/src/test/java/com/amplitude/api/AmplitudeClientTest.java
+++ b/src/test/java/com/amplitude/api/AmplitudeClientTest.java
@@ -2044,6 +2044,29 @@ public class AmplitudeClientTest extends BaseTest {
     }
 
     @Test
+    public void testSetIngestionMetadata() {
+        ShadowLooper looper = Shadows.shadowOf(amplitude.logThread.getLooper());
+        String sourceName = "ampli";
+        String sourceVersion = "1.0.0";
+        IngestionMetadata ingestionMetadata = new IngestionMetadata()
+                .setSourceName(sourceName)
+                .setSourceVersion(sourceVersion);
+        amplitude.setIngestionMetadata(ingestionMetadata);
+        amplitude.logEvent("test");
+        looper.runToEndOfTasks();
+
+        JSONObject event = getLastEvent();
+        assertNotNull(event);
+        try {
+            JSONObject jsonObject = event.getJSONObject("ingestion_metadata");
+            assertEquals(sourceName, jsonObject.getString("source_name"));
+            assertEquals(sourceVersion, jsonObject.getString("source_version"));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
     public void testSetServerZoneWithoutUpdateServerUrl() {
         String urlBeforeChange = amplitude.url;
         AmplitudeServerZone euZone = AmplitudeServerZone.EU;

--- a/src/test/java/com/amplitude/api/IngestionMetadataTest.java
+++ b/src/test/java/com/amplitude/api/IngestionMetadataTest.java
@@ -22,7 +22,7 @@ public class IngestionMetadataTest {
         ingestionMetadata.setSourceName(sourceName)
                 .setSourceVersion(sourceVersion);
         JSONObject result = ingestionMetadata.toJSONObject();
-        assertEquals(sourceName, result.getString(Constants.INGESTION_METADATA_SOURCE_NAME));
-        assertEquals(sourceVersion, result.getString(Constants.INGESTION_METADATA_SOURCE_VERSION));
+        assertEquals(sourceName, result.getString(Constants.AMP_INGESTION_METADATA_SOURCE_NAME));
+        assertEquals(sourceVersion, result.getString(Constants.AMP_INGESTION_METADATA_SOURCE_VERSION));
     }
 }

--- a/src/test/java/com/amplitude/api/IngestionMetadataTest.java
+++ b/src/test/java/com/amplitude/api/IngestionMetadataTest.java
@@ -1,0 +1,28 @@
+package com.amplitude.api;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@RunWith(AndroidJUnit4.class)
+@Config(manifest=Config.NONE)
+public class IngestionMetadataTest {
+
+    @Test
+    public void testToJSONObject() throws JSONException {
+        IngestionMetadata ingestionMetadata = new IngestionMetadata();
+        String sourceName = "ampli";
+        String sourceVersion = "1.0.0";
+        ingestionMetadata.setSourceName(sourceName)
+                .setSourceVersion(sourceVersion);
+        JSONObject result = ingestionMetadata.toJSONObject();
+        assertEquals(sourceName, result.getString(Constants.INGESTION_METADATA_SOURCE_NAME));
+        assertEquals(sourceVersion, result.getString(Constants.INGESTION_METADATA_SOURCE_VERSION));
+    }
+}


### PR DESCRIPTION
### Summary
- feat: add ingestion_metadata field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `ingestion_metadata` information.