### PR TITLE
doc: update badge to use 2.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <div align="center">
 
 [![Legacy SDK](https://img.shields.io/badge/state-legacy-yellow)](https://github.com/amplitude/Amplitude-Kotlin)
-[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk)](https://mvnrepository.com/artifact/com.amplitude/android-sdk/latest)
+[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk?versionPrefix=2)](https://mvnrepository.com/artifact/com.amplitude/android-sdk/latest)
 
 </div>
 


### PR DESCRIPTION
Update badge in doc to only reflect 2.x version