### PR TITLE
fix: check response code when response code is 200

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -2271,7 +2271,7 @@ public class AmplitudeClient {
         try {
             Response response = client.newCall(request).execute();
             String stringResponse = response.body().string();
-            if (stringResponse.equals("success")) {
+            if (response.code() == 200 || stringResponse.equals("success")) {
                 uploadSuccess = true;
                 logThread.post(new Runnable() {
                     @Override

--- a/src/test/java/com/amplitude/api/AmplitudeClientTest.java
+++ b/src/test/java/com/amplitude/api/AmplitudeClientTest.java
@@ -906,8 +906,8 @@ public class AmplitudeClientTest extends BaseTest {
         // unsent events will be threshold (+1 for start session)
         assertEquals(getUnsentEventCount(), Constants.EVENT_UPLOAD_THRESHOLD + 1);
 
-        server.enqueue(new MockResponse().setBody("invalid_api_key"));
-        server.enqueue(new MockResponse().setBody("bad_checksum"));
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("invalid_api_key"));
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("bad_checksum"));
         ShadowLooper httpLooper = Shadows.shadowOf(amplitude.httpThread.getLooper());
         httpLooper.runToEndOfTasks();
 


### PR DESCRIPTION
When making an event upload request, check the response code === 200 instead of checking the string response, in order to support the usage of a custom amplitude proxy.

https://github.com/amplitude/Amplitude-Android/issues/348
https://github.com/amplitude/Amplitude-JavaScript/pull/572