### PR TITLE
fix: move inForeground reads/writes to main thread

### DIFF
--- a/src/test/java/com/amplitude/api/SessionTest.java
+++ b/src/test/java/com/amplitude/api/SessionTest.java
@@ -169,7 +169,7 @@ public class SessionTest extends BaseTest {
         amplitude.trackSessionEvents(true);
 
         long timestamp = System.currentTimeMillis();
-        amplitude.logEvent("test", null, null, null, null, null, timestamp, false);
+        amplitude.logEventSync("test", null, null, timestamp, false);
         Shadows.shadowOf(amplitude.logThread.getLooper()).runToEndOfTasks();
         // trackSessions is true, start_session event is added
         assertEquals(getUnsentEventCount(), 2);
@@ -259,14 +259,14 @@ public class SessionTest extends BaseTest {
 
         // log 1st event, initialize first session
         long timestamp1 = System.currentTimeMillis();
-        amplitude.logEvent("test1", null, null, null, null, null, timestamp1, false);
+        amplitude.logEventSync("test1", null, null, timestamp1, false);
         looper.runToEndOfTasks();
         // trackSessions is true, start_session event is added
         assertEquals(getUnsentEventCount(), 2);
 
         // log 2nd event past timeout, verify new session started
         long timestamp2 = timestamp1 + sessionTimeoutMillis;
-        amplitude.logEvent("test2", null, null, null, null, null, timestamp2, false);
+        amplitude.logEventSync("test2", null, null, timestamp2, false);
         looper.runToEndOfTasks();
         // trackSessions is true, end_session and start_session events are added
         assertEquals(getUnsentEventCount(), 5);
@@ -370,13 +370,13 @@ public class SessionTest extends BaseTest {
 
         // log 3 events all just within session expiration window, verify all in same session
         long timestamp1 = System.currentTimeMillis();
-        amplitude.logEvent("test1", null, null, null, null, null, timestamp1, false);
+        amplitude.logEventSync("test1", null, null, timestamp1, false);
         looper.runToEndOfTasks();
         // trackSessions is true, start_session event is added
         assertEquals(getUnsentEventCount(), 2);
 
         long timestamp2 = timestamp1 + sessionTimeoutMillis - 1;
-        amplitude.logEvent("test2", null, null, null, null, null, timestamp2, false);
+        amplitude.logEventSync("test2", null, null, timestamp2, false);
         looper.runToEndOfTasks();
         assertEquals(getUnsentEventCount(), 3);
 


### PR DESCRIPTION
inForeground reads/writes moved to main thread.
The session logic has some differences compared to Amplitude-iOS. I would re-write session logic to match Ampltude-Kotlin/Amplitude-Swift implementation.
For some reason I have a few issues with the Amplitude-Android project on my machine with latest Android Studio:  unresolved identifiers in test files, `./gradlew build` fails with `204 tests completed, 35 failed` (but in Android Studio UI all tests are green).