### PR TITLE
fix: do not fetch advertising Id if adid tracking is disabled

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -2395,7 +2395,7 @@ public class AmplitudeClient {
     }
 
     protected DeviceInfo initializeDeviceInfo() {
-        return new DeviceInfo(context, this.locationListening);
+        return new DeviceInfo(context, this.locationListening, appliedTrackingOptions.shouldTrackAdid());
     }
 
     /**

--- a/src/main/java/com/amplitude/api/DeviceInfo.java
+++ b/src/main/java/com/amplitude/api/DeviceInfo.java
@@ -33,7 +33,9 @@ public class DeviceInfo {
     private static final String SETTING_LIMIT_AD_TRACKING = "limit_ad_tracking";
     private static final String SETTING_ADVERTISING_ID = "advertising_id";
 
-    private boolean locationListening = true;
+    private boolean locationListening;
+
+    private boolean shouldTrackAdid;
 
     private Context context;
 
@@ -213,6 +215,10 @@ public class DeviceInfo {
         }
 
         private String getAdvertisingId() {
+            if (!shouldTrackAdid) {
+                return null;
+            }
+
             // This should not be called on the main thread.
             if ("Amazon".equals(getManufacturer())) {
                 return getAndCacheAmazonAdvertisingId();
@@ -308,9 +314,10 @@ public class DeviceInfo {
         }
     }
 
-    public DeviceInfo(Context context, boolean locationListening) {
+    public DeviceInfo(Context context, boolean locationListening, boolean shouldTrackAdid) {
         this.context = context;
         this.locationListening = locationListening;
+        this.shouldTrackAdid = shouldTrackAdid;
     }
 
     private CachedInfo getCachedInfo() {


### PR DESCRIPTION
Additional note: in Android-Kotlin default value for `limitAdTrackingEnabled` is `true`, in Amplitude-Android - `false`
* https://github.com/amplitude/Amplitude-Kotlin/blob/main/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt#L51
* https://github.com/amplitude/Amplitude-Android/blob/main/src/main/java/com/amplitude/api/DeviceInfo.java#L56

Maybe if adid tracking is disabled `limitAdTrackingEnabled` should be `null`.