### PR TITLE
fix: try to reduce sqlite cursor memory usage

### DIFF
--- a/src/main/java/com/amplitude/api/IdentifyInterceptor.java
+++ b/src/main/java/com/amplitude/api/IdentifyInterceptor.java
@@ -92,27 +92,6 @@ class IdentifyInterceptor {
         this.identifyBatchIntervalMillis = identifyBatchIntervalMillis;
     }
 
-    private JSONObject fetchAndMergeToIdentifyEvent(JSONObject event) {
-        try {
-            List<JSONObject> identifys = dbHelper.getIdentifyInterceptors(lastIdentifyInterceptorId, -1);
-            if (identifys.isEmpty()) {
-                return event;
-            }
-            JSONObject identifyEventUserProperties = event.getJSONObject("user_properties");
-            JSONObject userProperties = mergeIdentifyInterceptList(identifys);
-            if (identifyEventUserProperties.has(Constants.AMP_OP_SET)) {
-                mergeUserProperties(userProperties, identifyEventUserProperties.getJSONObject(Constants.AMP_OP_SET));
-            }
-            identifyEventUserProperties.put(Constants.AMP_OP_SET, userProperties);
-            event.put("user_properties", identifyEventUserProperties);
-            dbHelper.removeIdentifyInterceptors(lastIdentifyInterceptorId);
-            return event;
-        } catch (JSONException e) {
-            AmplitudeLog.getLogger().w(TAG, "Identify Merge error: " + e.getMessage());
-        }
-        return event;
-    }
-
     private JSONObject getTransferIdentifyEvent() {
         try {
             List<JSONObject> identifys = dbHelper.getIdentifyInterceptors(lastIdentifyInterceptorId, -1);
@@ -152,22 +131,6 @@ class IdentifyInterceptor {
             return;
         }
         client.saveEvent(Constants.IDENTIFY_EVENT, identifyEvent);
-    }
-
-    private JSONObject fetchAndMergeToNormalEvent(JSONObject event) {
-        try {
-            List<JSONObject> identifys = dbHelper.getIdentifyInterceptors(lastIdentifyInterceptorId, -1);
-            if (identifys.isEmpty()) {
-                return event;
-            }
-            JSONObject userProperties = mergeIdentifyInterceptList(identifys);
-            mergeUserProperties(userProperties, event.getJSONObject("user_properties"));
-            event.put("user_properties", userProperties);
-            dbHelper.removeIdentifyInterceptors(lastIdentifyInterceptorId);
-        } catch (JSONException e) {
-            AmplitudeLog.getLogger().w(TAG, "Identify Merge error: " + e.getMessage());
-        }
-        return event;
     }
 
     private JSONObject mergeIdentifyInterceptList(List<JSONObject> identifys) throws JSONException {


### PR DESCRIPTION
https://github.com/amplitude/Amplitude-Android/blob/main/CHANGELOG.md#2100-oct-12-2016 

```
## 2.10.0 (Oct 12, 2016)
Catch and handle CursorWindowAllocationException thrown when the SDK is querying from > the SQLite DB when app memory is low.
If the exception is caught during initialize, then it is treated as if initialize was > never called.
If the exception is caught during the uploading of unsent events, then the upload is deferred to a later time.
```

https://github.com/amplitude/Amplitude-Android/blob/main/src/main/java/com/amplitude/api/AmplitudeClient.java#L444 

```
} catch (CursorWindowAllocationException e) {  // treat as uninitialized SDK
      logger.e(TAG, String.format(
              "Failed to initialize Amplitude SDK due to: %s", e.getMessage()
      ));
      client.apiKey = null;
}
````

https://github.com/amplitude/Amplitude-Android/blob/main/src/main/java/com/amplitude/api/AmplitudeClient.java#L2187

```
} catch (CursorWindowAllocationException e) {
     // handle CursorWindowAllocationException when fetching events, defer upload
     uploadingCurrently.set(false);
      logger.e(TAG, String.format(
         "Caught Cursor window exception during event upload, deferring upload: %s",
          e.getMessage()
      ));
}
```

New logic was added recently (`IdentifyInterceptor.transferInterceptedIdentify`) that can throw `CursorWindowAllocationException` - the exception is not caught/handled in this case. I believe, we can’t defer `transferInterceptedIdentify` call (similar to `If the exception is caught during the uploading of unsent events, then the upload is deferred to a later time`).

To reduce cursor memory usage now each event is loaded from sqlite database with separate query/cursor. Hope it helps.

Currently my environment doesn't work with Amplitude-Android (build/test) - so I didn't test properly (CI tests only).

Some unused code is removed.