### PR TITLE
chore: revert to @google/semantic-release-replace-plugin@1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,6 @@ jobs:
           -p semantic-release@17 \
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
-          -p @google/semantic-release-replace-plugin@1.2.0 \
+          -p @google/semantic-release-replace-plugin@1 \
           -p @semantic-release/exec@5 \
           semantic-release


### PR DESCRIPTION
Author released a new version `@google/semantic-release-replace-plugin@1.2.4` with a fix to ESM errors