### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           -p semantic-release@17 \
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
-          -p @google/semantic-release-replace-plugin@1.2.0 \
+          -p semantic-release-replace-plugin@1.2.0 \
           -p @semantic-release/exec@5 \
           semantic-release --dry-run
 
@@ -97,6 +97,6 @@ jobs:
           -p semantic-release@17 \
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
-          -p @google/semantic-release-replace-plugin@1.2.0 \
+          -p semantic-release-replace-plugin@1.2.0 \
           -p @semantic-release/exec@5 \
           semantic-release

--- a/release.config.js
+++ b/release.config.js
@@ -19,7 +19,7 @@ module.exports = {
     }],
     "@semantic-release/github",
     [
-      "@google/semantic-release-replace-plugin",
+      "semantic-release-replace-plugin",
       {
         "replacements": [
           {


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).