### PR TITLE
fix: try to correctly handle session change for race condition

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -181,6 +181,7 @@ public class AmplitudeClient {
     private boolean usingForegroundTracking = false;
     private boolean trackingSessionEvents = false;
     private boolean inForeground = false;
+    private boolean isEnteringForeground = false;
     private boolean flushEventsOnClose = true;
     private String libraryName = Constants.LIBRARY;
     private String libraryVersion = Constants.VERSION;
@@ -1221,7 +1222,8 @@ public class AmplitudeClient {
 
         if (!loggingSessionEvent && !outOfSession) {
             // default case + corner case when async logEvent between onPause and onResume
-            if (!inForeground){
+            if (!inForeground || isEnteringForeground){
+                isEnteringForeground = false;
                 startNewSessionIfNeeded(timestamp);
             } else {
                 refreshSessionTime(timestamp);
@@ -1602,6 +1604,7 @@ public class AmplitudeClient {
      * @param timestamp the timestamp
      */
     void onEnterForeground(final long timestamp) {
+        isEnteringForeground = true;
         inForeground = true;
         runOnLogThread(new Runnable() {
             @Override
@@ -1617,7 +1620,13 @@ public class AmplitudeClient {
                         }
                     }, serverZone);
                 }
-                startNewSessionIfNeeded(timestamp);
+                // This should be true, unless somehow an event was tracked
+                // between here and the beginning of this method
+                // in that case the session is started in logEvent()
+                if (isEnteringForeground) {
+                    startNewSessionIfNeeded(timestamp);
+                }
+                isEnteringForeground = false;
             }
         });
     }

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -1575,6 +1575,7 @@ public class AmplitudeClient {
      * @param timestamp the timestamp
      */
     void onExitForeground(final long timestamp) {
+        isEnteringForeground = false;
         inForeground = false;
         runOnLogThread(new Runnable() {
             @Override


### PR DESCRIPTION
# Description

We are [still getting long sessions for some customers in Flutter on Android](https://amplitude.atlassian.net/browse/AMP-76734?focusedCommentId=198409) after the other session fixes.

This change aims to handle the hypothetical case where an event is tracked before the `runOnLogThread(new Runnable()` executes.

That scenario would lead the event being "in foreground" which would extend the existing session.

Maybe it is also possible to move setting `inForeground` to the first line of the onEnterForeground Runnable? wdyt @falconandy?

```diff
void onEnterForeground(final long timestamp) {
-        inForeground = true;
        runOnLogThread(new Runnable() {
            @Override
            public void run() {
+             inForeground = true;
```

https://github.com/amplitude/Amplitude-Android/pull/362/files 