### PR TITLE
feat: middleware session replay integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: [authorize]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -2122,6 +2122,7 @@ public class AmplitudeClient {
                 }
                 identifyInterceptor.transferInterceptedIdentify();
                 updateServer();
+                middlewareRunner.flush();
             }
         });
     }

--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -738,6 +738,10 @@ public class AmplitudeClient {
         return this;
     }
 
+    public Boolean getOptOut() {
+        return optOut;
+    }
+
     /**
      * Library name is default as `amplitude-android`.
      * Notice: You will only want to set it when following conditions are met.

--- a/src/main/java/com/amplitude/api/MiddlewareExtended.java
+++ b/src/main/java/com/amplitude/api/MiddlewareExtended.java
@@ -1,0 +1,5 @@
+package com.amplitude.api;
+
+interface MiddlewareExtended extends Middleware {
+	void flush();
+}

--- a/src/main/java/com/amplitude/api/MiddlewareRunner.java
+++ b/src/main/java/com/amplitude/api/MiddlewareRunner.java
@@ -44,4 +44,12 @@ public class MiddlewareRunner {
         List<Middleware> middlewareList = new ArrayList<>(this.middlewares);
         runMiddlewares(middlewareList, payload, next);
     }
+
+    void flush() {
+        for (Middleware middleware : middlewares) {
+            if (middleware instanceof MiddlewareExtended) {
+                ((MiddlewareExtended) middleware).flush();
+            }
+        }
+    }
 }

--- a/src/test/java/com/amplitude/api/MiddlewareRunnerTest.java
+++ b/src/test/java/com/amplitude/api/MiddlewareRunnerTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 @RunWith(AndroidJUnit4.class)
 @Config(manifest= Config.NONE)
 public class MiddlewareRunnerTest {
@@ -81,27 +83,27 @@ public class MiddlewareRunnerTest {
 
     @Test
     public void testMiddlewareFlush() throws JSONException {
-        int flushCount = 0;
-        int runCount = 0;
+        AtomicInteger runCount = new AtomicInteger(0);
+        AtomicInteger flushCount = new AtomicInteger(0);
 
         MiddlewareExtended flushMiddleware = new MiddlewareExtended() {
             @Override
             public void run(MiddlewarePayload payload, MiddlewareNext next) {
-                runCount += 1;
+                runCount.incrementAndGet();
             }
 
             @Override
-            void flush() {
-                flushCount += 1;
+            public void flush() {
+                flushCount.incrementAndGet();
             }
         };
+
         middlewareRunner.add(flushMiddleware);
 
-        boolean middlewareCompleted = middlewareRunner.flush();
+        middlewareRunner.flush();
 
-        assertTrue(middlewareCompleted);
-        assertEquals(flushCount, 1);
-        assertEquals(runCount, 0);
+        assertEquals(flushCount.get(), 1);
+        assertEquals(runCount.get(), 0);
     }
 
 }

--- a/src/test/java/com/amplitude/api/MiddlewareRunnerTest.java
+++ b/src/test/java/com/amplitude/api/MiddlewareRunnerTest.java
@@ -79,4 +79,29 @@ public class MiddlewareRunnerTest {
         assertEquals(event.getString("user_id"), middlewareUser);
     }
 
+    @Test
+    public void testMiddlewareFlush() throws JSONException {
+        int flushCount = 0;
+        int runCount = 0;
+
+        MiddlewareExtended flushMiddleware = new MiddlewareExtended() {
+            @Override
+            public void run(MiddlewarePayload payload, MiddlewareNext next) {
+                runCount += 1;
+            }
+
+            @Override
+            void flush() {
+                flushCount += 1;
+            }
+        };
+        middlewareRunner.add(flushMiddleware);
+
+        boolean middlewareCompleted = middlewareRunner.flush();
+
+        assertTrue(middlewareCompleted);
+        assertEquals(flushCount, 1);
+        assertEquals(runCount, 0);
+    }
+
 }


### PR DESCRIPTION
[AMP-97797]

Updates to core SDK to support session replay middleware

* Add AmplitudeClient.getOptOut() to allow SR middleware to use client optOut value
* Add MiddlewareExtended and MiddlewareRunner.flush() to allow automatic flushing of SR events on `flushEventsOnClose=true` and `amplitude.uploadEvents()`

[AMP-97797]: https://amplitude.atlassian.net/browse/AMP-97797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ