### PR TITLE
fix: always run middleware flush on updateServer

### DIFF
--- a/src/main/java/com/amplitude/api/AmplitudeClient.java
+++ b/src/main/java/com/amplitude/api/AmplitudeClient.java
@@ -2122,7 +2122,6 @@ public class AmplitudeClient {
                 }
                 identifyInterceptor.transferInterceptedIdentify();
                 updateServer();
-                middlewareRunner.flush();
             }
         });
     }
@@ -2158,6 +2157,9 @@ public class AmplitudeClient {
         if (optOut || offline) {
             return;
         }
+
+        // Flush middleware
+        middlewareRunner.flush();
 
         // if returning out of this block, always be sure to set uploadingCurrently to false!!
         if (!uploadingCurrently.getAndSet(true)) {


### PR DESCRIPTION
MiddlewareRunner.flush() wasn't always called on updateServer (there are multiple locations updateServer is called)